### PR TITLE
Adds the possibility to implement Bots (Characters controlled by the AI)

### DIFF
--- a/networked_controller.cpp
+++ b/networked_controller.cpp
@@ -163,6 +163,14 @@ NetworkedController::NetworkedController() {
 	rpc_config(SNAME("_rpc_doll_send_epoch_batch"), Multiplayer::RPC_MODE_ANY_PEER, call_local, Multiplayer::TRANSFER_MODE_UNRELIABLE);
 }
 
+NetworkedController::~NetworkedController() {
+	if (controller != nullptr) {
+		memdelete(controller);
+		controller = nullptr;
+		controller_type = CONTROLLER_TYPE_NULL;
+	}
+}
+
 void NetworkedController::set_server_controlled(bool p_server_controlled) {
 	if (server_controlled == p_server_controlled) {
 		// It's the same, nothing to do.

--- a/networked_controller.cpp
+++ b/networked_controller.cpp
@@ -49,6 +49,9 @@
 #define TICK_SPEED_CHANGE_NOTIF_THRESHOLD 4
 
 void NetworkedController::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_server_controlled", "server_controlled"), &NetworkedController::set_server_controlled);
+	ClassDB::bind_method(D_METHOD("get_server_controlled"), &NetworkedController::get_server_controlled);
+
 	ClassDB::bind_method(D_METHOD("set_player_input_storage_size", "size"), &NetworkedController::set_player_input_storage_size);
 	ClassDB::bind_method(D_METHOD("get_player_input_storage_size"), &NetworkedController::get_player_input_storage_size);
 
@@ -108,6 +111,7 @@ void NetworkedController::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_doll_peer_active", "peer_id", "active"), &NetworkedController::set_doll_peer_active);
 
 	ClassDB::bind_method(D_METHOD("_rpc_server_send_inputs"), &NetworkedController::_rpc_server_send_inputs);
+	ClassDB::bind_method(D_METHOD("_rpc_set_server_controlled"), &NetworkedController::_rpc_set_server_controlled);
 	ClassDB::bind_method(D_METHOD("_rpc_send_tick_additional_speed"), &NetworkedController::_rpc_send_tick_additional_speed);
 	ClassDB::bind_method(D_METHOD("_rpc_doll_notify_sync_pause"), &NetworkedController::_rpc_doll_notify_sync_pause);
 	ClassDB::bind_method(D_METHOD("_rpc_doll_send_epoch_batch"), &NetworkedController::_rpc_doll_send_epoch_batch);
@@ -128,6 +132,7 @@ void NetworkedController::_bind_methods() {
 	GDVIRTUAL_BIND(_parse_epoch_data, "interpolator", "buffer");
 	GDVIRTUAL_BIND(_apply_epoch, "delta", "interpolated_data");
 
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "server_controlled"), "set_server_controlled", "get_server_controlled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "input_storage_size", PROPERTY_HINT_RANGE, "5,2000,1"), "set_player_input_storage_size", "get_player_input_storage_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_redundant_inputs", PROPERTY_HINT_RANGE, "0,1000,1"), "set_max_redundant_inputs", "get_max_redundant_inputs");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tick_speedup_notification_delay", PROPERTY_HINT_RANGE, "0.001,2.0,0.001"), "set_tick_speedup_notification_delay", "get_tick_speedup_notification_delay");
@@ -152,9 +157,60 @@ void NetworkedController::_bind_methods() {
 NetworkedController::NetworkedController() {
 	constexpr bool call_local = false;
 	rpc_config(SNAME("_rpc_server_send_inputs"), Multiplayer::RPC_MODE_ANY_PEER, call_local, Multiplayer::TRANSFER_MODE_UNRELIABLE);
+	rpc_config(SNAME("_rpc_set_server_controlled"), Multiplayer::RPC_MODE_ANY_PEER, call_local, Multiplayer::TRANSFER_MODE_RELIABLE);
 	rpc_config(SNAME("_rpc_send_tick_additional_speed"), Multiplayer::RPC_MODE_ANY_PEER, call_local, Multiplayer::TRANSFER_MODE_UNRELIABLE);
 	rpc_config(SNAME("_rpc_doll_notify_sync_pause"), Multiplayer::RPC_MODE_ANY_PEER, call_local, Multiplayer::TRANSFER_MODE_RELIABLE);
 	rpc_config(SNAME("_rpc_doll_send_epoch_batch"), Multiplayer::RPC_MODE_ANY_PEER, call_local, Multiplayer::TRANSFER_MODE_UNRELIABLE);
+}
+
+void NetworkedController::set_server_controlled(bool p_server_controlled) {
+	if (server_controlled == p_server_controlled) {
+		// It's the same, nothing to do.
+		return;
+	}
+
+	if (is_networking_initialized()) {
+		if (is_server_controller()) {
+			// This is the server, let's start the procedure to switch controll mode.
+
+#ifdef DEBUG_ENABLED
+			CRASH_COND_MSG(scene_synchronizer == nullptr, "When the `NetworkedController` is a server, the `scene_synchronizer` is always set.");
+#endif
+
+			// First update the variable.
+			server_controlled = p_server_controlled;
+
+			// Notify the `SceneSynchronizer` about it.
+			scene_synchronizer->notify_controller_control_mode_changed(this);
+
+			// Tell the client to do the switch too.
+			rpc_id(
+					get_multiplayer_authority(),
+					SNAME("_rpc_set_server_controlled"),
+					server_controlled);
+
+		} else if (is_player_controller() || is_doll_controller()) {
+			NET_DEBUG_WARN("You should never call the function `set_server_controlled` on the client, this has an effect only if called on the server.");
+
+		} else if (is_nonet_controller()) {
+			// There is no networking, the same instance is both the client and the
+			// server already, nothing to do.
+			server_controlled = p_server_controlled;
+
+		} else {
+#ifdef DEBUG_ENABLED
+			CRASH_NOW_MSG("Unreachable, all the cases are handled.");
+#endif
+		}
+	} else {
+		// This called during initialization or on the editor, nothing special just
+		// set it.
+		server_controlled = p_server_controlled;
+	}
+}
+
+bool NetworkedController::get_server_controlled() const {
+	return server_controlled;
 }
 
 void NetworkedController::set_player_input_storage_size(int p_size) {
@@ -394,8 +450,12 @@ const NoNetController *NetworkedController::get_nonet_controller() const {
 	return static_cast<const NoNetController *>(controller);
 }
 
+bool NetworkedController::is_networking_initialized() const {
+	return controller_type != CONTROLLER_TYPE_NULL;
+}
+
 bool NetworkedController::is_server_controller() const {
-	return controller_type == CONTROLLER_TYPE_SERVER;
+	return controller_type == CONTROLLER_TYPE_SERVER || controller_type == CONTROLLER_TYPE_AUTONOMOUS_SERVER;
 }
 
 bool NetworkedController::is_player_controller() const {
@@ -438,6 +498,14 @@ bool NetworkedController::has_scene_synchronizer() const {
 void NetworkedController::_rpc_server_send_inputs(const Vector<uint8_t> &p_data) {
 	ERR_FAIL_COND(is_server_controller() == false);
 	static_cast<ServerController *>(controller)->receive_inputs(p_data);
+}
+
+void NetworkedController::_rpc_set_server_controlled(bool p_server_controlled) {
+	ERR_FAIL_COND_MSG(is_player_controller() == false, "This function is supposed to be called on the server.");
+	server_controlled = p_server_controlled;
+
+	ERR_FAIL_COND_MSG(scene_synchronizer == nullptr, "The server controller is supposed to be set on the client at this point.");
+	scene_synchronizer->notify_controller_control_mode_changed(this);
 }
 
 void NetworkedController::_rpc_send_tick_additional_speed(const Vector<uint8_t> &p_data) {
@@ -526,7 +594,7 @@ void ServerController::process(real_t p_delta) {
 		return;
 	}
 
-	fetch_next_input();
+	fetch_next_input(p_delta);
 
 	if (unlikely(current_input_buffer_id == UINT32_MAX)) {
 		// Skip this until the first input arrive.
@@ -733,7 +801,7 @@ int ServerController::get_inputs_count() const {
 	return snapshots.size();
 }
 
-bool ServerController::fetch_next_input() {
+bool ServerController::fetch_next_input(real_t p_delta) {
 	bool is_new_input = true;
 
 	if (unlikely(current_input_buffer_id == UINT32_MAX)) {
@@ -1070,6 +1138,38 @@ uint32_t ServerController::find_peer(int p_peer) const {
 	return UINT32_MAX;
 }
 
+AutonomousServerController::AutonomousServerController(
+		NetworkedController *p_node) :
+		ServerController(p_node, 1) {
+}
+
+void AutonomousServerController::receive_inputs(const Vector<uint8_t> &p_data) {
+	NET_DEBUG_WARN("`receive_input` called on the `AutonomousServerController` - If this is called just after `set_server_controlled(true)` is called, you can ignore this warning, as the client is not aware about the switch for a really small window after this function call.");
+}
+
+int AutonomousServerController::get_inputs_count() const {
+	// No input collected by this class.
+	return 0;
+}
+
+bool AutonomousServerController::fetch_next_input(real_t p_delta) {
+	node->get_inputs_buffer_mut().begin_write(METADATA_SIZE);
+	node->get_inputs_buffer_mut().seek(METADATA_SIZE);
+	node->call(SNAME("_collect_inputs"), p_delta, &node->get_inputs_buffer_mut());
+	node->get_inputs_buffer_mut().dry();
+
+	if (unlikely(current_input_buffer_id == UINT32_MAX)) {
+		// This is the first input.
+		current_input_buffer_id = 0;
+	} else {
+		// Just advance from now on.
+		current_input_buffer_id += 1;
+	}
+
+	// The input is always new.
+	return true;
+}
+
 PlayerController::PlayerController(NetworkedController *p_node) :
 		Controller(p_node),
 		current_input_id(UINT32_MAX),
@@ -1090,7 +1190,7 @@ void PlayerController::process(real_t p_delta) {
 
 		node->get_inputs_buffer_mut().begin_write(METADATA_SIZE);
 
-		node->get_inputs_buffer_mut().seek(1);
+		node->get_inputs_buffer_mut().seek(METADATA_SIZE);
 		GDVIRTUAL_CALL_PTR(node, _collect_inputs, p_delta, &node->get_inputs_buffer_mut());
 
 		// Set metadata data.

--- a/networked_controller.h
+++ b/networked_controller.h
@@ -246,6 +246,7 @@ public:
 
 public:
 	NetworkedController();
+	~NetworkedController();
 
 	void set_server_controlled(bool p_server_controlled);
 	bool get_server_controlled() const;

--- a/networked_controller.h
+++ b/networked_controller.h
@@ -77,6 +77,7 @@ public:
 		CONTROLLER_TYPE_NULL,
 		CONTROLLER_TYPE_NONETWORK,
 		CONTROLLER_TYPE_PLAYER,
+		CONTROLLER_TYPE_AUTONOMOUS_SERVER,
 		CONTROLLER_TYPE_SERVER,
 		CONTROLLER_TYPE_DOLL
 	};
@@ -91,6 +92,18 @@ public:
 	GDVIRTUAL2(_apply_epoch, real_t, Array);
 
 private:
+	/// When `true`, this controller is controlled by the server: All the clients
+	/// see it as a `Doll`.
+	/// This property is really useful to implement bots (Character controlled by
+	/// the AI).
+	///
+	/// NOTICE: Generally you specify this property on the editor, in addition
+	/// it's possible to change this at runtime: this will cause the server to
+	/// notify all the clients; so the switch is not immediate. This feature can be
+	/// used to switch the Character possession between the AI (Server) and
+	/// PlayerController (Client) without the need to re-instantiate the Character.
+	bool server_controlled = false;
+
 	/// The input storage size is used to cap the amount of inputs collected by
 	/// the `PlayerController`.
 	///
@@ -234,6 +247,9 @@ public:
 public:
 	NetworkedController();
 
+	void set_server_controlled(bool p_server_controlled);
+	bool get_server_controlled() const;
+
 	void set_player_input_storage_size(int p_size);
 	int get_player_input_storage_size() const;
 
@@ -316,6 +332,7 @@ public:
 	NoNetController *get_nonet_controller();
 	const NoNetController *get_nonet_controller() const;
 
+	bool is_networking_initialized() const;
 	bool is_server_controller() const;
 	bool is_player_controller() const;
 	bool is_doll_controller() const;
@@ -332,6 +349,7 @@ public:
 	void _rpc_server_send_inputs(const Vector<uint8_t> &p_data);
 
 	/* On client rpc functions. */
+	void _rpc_set_server_controlled(bool p_server_controlled);
 	void _rpc_send_tick_additional_speed(const Vector<uint8_t> &p_data);
 
 	/* On puppet rpc functions. */
@@ -424,11 +442,11 @@ struct ServerController : public Controller {
 	virtual void activate_peer(int p_peer) override;
 	virtual void deactivate_peer(int p_peer) override;
 
-	void receive_inputs(const Vector<uint8_t> &p_data);
-	int get_inputs_count() const;
+	virtual void receive_inputs(const Vector<uint8_t> &p_data);
+	virtual int get_inputs_count() const;
 
 	/// Fetch the next inputs, returns true if the input is new.
-	bool fetch_next_input();
+	virtual bool fetch_next_input(real_t p_delta);
 
 	void notify_send_state();
 
@@ -449,6 +467,15 @@ struct ServerController : public Controller {
 	void adjust_player_tick_rate(real_t p_delta);
 
 	uint32_t find_peer(int p_peer) const;
+};
+
+struct AutonomousServerController : public ServerController {
+	AutonomousServerController(
+			NetworkedController *p_node);
+
+	virtual void receive_inputs(const Vector<uint8_t> &p_data) override;
+	virtual int get_inputs_count() const override;
+	virtual bool fetch_next_input(real_t p_delta) override;
 };
 
 struct PlayerController : public Controller {

--- a/scene_synchronizer.cpp
+++ b/scene_synchronizer.cpp
@@ -156,8 +156,8 @@ void SceneSynchronizer::_notification(int p_what) {
 
 			// Init the peers already connected.
 			if (get_tree()->get_multiplayer()->get_multiplayer_peer().is_valid()) {
-				const RBSet<int> peer_ids = get_tree()->get_multiplayer()->get_connected_peers();
-				for (RBSet<int>::ConstIterator it = peer_ids.begin(); it != peer_ids.end(); ++it) {
+				const HashSet<int> peer_ids = get_tree()->get_multiplayer()->get_connected_peers();
+				for (HashSet<int>::Iterator it = peer_ids.begin(); it != peer_ids.end(); ++it) {
 					_on_peer_connected(*it);
 				}
 			}

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -249,6 +249,8 @@ public:
 	void reset_synchronizer_mode();
 	void clear();
 
+	void notify_controller_control_mode_changed(NetworkedController *controller);
+
 	void _rpc_send_state(const Variant &p_snapshot);
 	void _rpc_notify_need_full_snapshot();
 	void _rpc_set_network_enabled(bool p_enabled);


### PR DESCRIPTION
Port of: https://github.com/GodotNetworking/network_synchronizer/pull/1

Adds the possibility to implement Bots (Characters controlled by the AI)

This commit introduces the concept of controlled by the server on
the NetworkedController: When this property is set to true the
server collects the inputs and process the controlled object -> all the
other clients will see it as a doll.

Notice, it's possible to change server_controlled at runtime to switch
from player controller to AI controlled and vice versa.
