### PR TITLE
fix for server performing redundant operations when 'server controlled'

### DIFF
--- a/networked_controller.cpp
+++ b/networked_controller.cpp
@@ -1179,11 +1179,11 @@ bool AutonomousServerController::fetch_next_input(real_t p_delta) {
 }
 
 void AutonomousServerController::calculates_player_tick_rate(real_t p_delta) {
-	//No need to perform it in server controlled scenario
+	// Nothing to do, since the inputs are being collected on the server already.
 }
 
 void AutonomousServerController::adjust_player_tick_rate(real_t p_delta) {
-	//No need to perform it in server controlled scenario
+	// Nothing to do, since the inputs are being collected on the server already.
 }
 
 PlayerController::PlayerController(NetworkedController *p_node) :

--- a/networked_controller.cpp
+++ b/networked_controller.cpp
@@ -1178,6 +1178,14 @@ bool AutonomousServerController::fetch_next_input(real_t p_delta) {
 	return true;
 }
 
+void AutonomousServerController::calculates_player_tick_rate(real_t p_delta) {
+	//No need to perform it in server controlled scenario
+}
+
+void AutonomousServerController::adjust_player_tick_rate(real_t p_delta) {
+	//No need to perform it in server controlled scenario
+}
+
 PlayerController::PlayerController(NetworkedController *p_node) :
 		Controller(p_node),
 		current_input_id(UINT32_MAX),

--- a/networked_controller.h
+++ b/networked_controller.h
@@ -464,8 +464,8 @@ struct ServerController : public Controller {
 	/// the server is artificial and no more dependent on the internet. For this
 	/// reason the server tells the client to slowdown so to keep the `frames_inputs`
 	/// size moderate to the needs.
-	void calculates_player_tick_rate(real_t p_delta);
-	void adjust_player_tick_rate(real_t p_delta);
+	virtual void calculates_player_tick_rate(real_t p_delta);
+	virtual void adjust_player_tick_rate(real_t p_delta);
 
 	uint32_t find_peer(int p_peer) const;
 };
@@ -477,6 +477,8 @@ struct AutonomousServerController : public ServerController {
 	virtual void receive_inputs(const Vector<uint8_t> &p_data) override;
 	virtual int get_inputs_count() const override;
 	virtual bool fetch_next_input(real_t p_delta) override;
+	virtual void calculates_player_tick_rate(real_t p_delta) override;
+	virtual void adjust_player_tick_rate(real_t p_delta) override;
 };
 
 struct PlayerController : public Controller {


### PR DESCRIPTION
For nodes which are server controlled, AuthonomousSeverController was trying to perform operations which makes sense only when player is controlling a node.
It resulted in an 'ERROR: RPC '_rpc_send_tick_additional_speed' error print, couple times a second