### PR TITLE
Add native code support & InputNetowkEncode.

### DIFF
--- a/data_buffer.cpp
+++ b/data_buffer.cpp
@@ -644,6 +644,11 @@ void DataBuffer::skip_real(CompressionLevel p_compression) {
 	skip(bits);
 }
 
+void DataBuffer::skip_positive_unit_real(CompressionLevel p_compression) {
+	const int bits = get_positive_unit_real_size(p_compression);
+	skip(bits);
+}
+
 void DataBuffer::skip_unit_real(CompressionLevel p_compression) {
 	const int bits = get_unit_real_size(p_compression);
 	skip(bits);
@@ -681,6 +686,10 @@ int DataBuffer::get_real_size(CompressionLevel p_compression) const {
 	return DataBuffer::get_bit_taken(DATA_TYPE_REAL, p_compression);
 }
 
+int DataBuffer::get_positive_unit_real_size(CompressionLevel p_compression) const {
+	return DataBuffer::get_bit_taken(DATA_TYPE_POSITIVE_UNIT_REAL, p_compression);
+}
+
 int DataBuffer::get_unit_real_size(CompressionLevel p_compression) const {
 	return DataBuffer::get_bit_taken(DATA_TYPE_UNIT_REAL, p_compression);
 }
@@ -715,6 +724,12 @@ int DataBuffer::read_int_size(CompressionLevel p_compression) {
 
 int DataBuffer::read_real_size(CompressionLevel p_compression) {
 	const int bits = get_real_size(p_compression);
+	skip(bits);
+	return bits;
+}
+
+int DataBuffer::read_positive_unit_real_size(CompressionLevel p_compression) {
+	const int bits = get_positive_unit_real_size(p_compression);
 	skip(bits);
 	return bits;
 }
@@ -803,7 +818,7 @@ int DataBuffer::get_bit_taken(DataType p_data_type, CompressionLevel p_compressi
 		} break;
 		case DATA_TYPE_REAL: {
 			return get_mantissa_bits(p_compression) +
-				   get_exponent_bits(p_compression);
+					get_exponent_bits(p_compression);
 		} break;
 		case DATA_TYPE_POSITIVE_UNIT_REAL: {
 			switch (p_compression) {

--- a/data_buffer.h
+++ b/data_buffer.h
@@ -294,6 +294,7 @@ public:
 	void skip_bool();
 	void skip_int(CompressionLevel p_compression);
 	void skip_real(CompressionLevel p_compression);
+	void skip_positive_unit_real(CompressionLevel p_compression);
 	void skip_unit_real(CompressionLevel p_compression);
 	void skip_vector2(CompressionLevel p_compression);
 	void skip_normalized_vector2(CompressionLevel p_compression);
@@ -305,6 +306,7 @@ public:
 	int get_bool_size() const;
 	int get_int_size(CompressionLevel p_compression) const;
 	int get_real_size(CompressionLevel p_compression) const;
+	int get_positive_unit_real_size(CompressionLevel p_compression) const;
 	int get_unit_real_size(CompressionLevel p_compression) const;
 	int get_vector2_size(CompressionLevel p_compression) const;
 	int get_normalized_vector2_size(CompressionLevel p_compression) const;
@@ -316,6 +318,7 @@ public:
 	int read_bool_size();
 	int read_int_size(CompressionLevel p_compression);
 	int read_real_size(CompressionLevel p_compression);
+	int read_positive_unit_real_size(CompressionLevel p_compression);
 	int read_unit_real_size(CompressionLevel p_compression);
 	int read_vector2_size(CompressionLevel p_compression);
 	int read_normalized_vector2_size(CompressionLevel p_compression);

--- a/input_network_encoder.cpp
+++ b/input_network_encoder.cpp
@@ -1,0 +1,371 @@
+#include "input_network_encoder.h"
+
+#include "scene_synchronizer.h"
+
+void InputNetworkEncoder::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("register_input", "name", "default_value", "type", "compression_level"), &InputNetworkEncoder::register_input);
+	ClassDB::bind_method(D_METHOD("find_input_id", "name"), &InputNetworkEncoder::find_input_id);
+	ClassDB::bind_method(D_METHOD("encode", "inputs", "buffer"), &InputNetworkEncoder::script_encode);
+	ClassDB::bind_method(D_METHOD("decode", "buffer", "inputs"), &InputNetworkEncoder::script_decode);
+	ClassDB::bind_method(D_METHOD("get_defaults"), &InputNetworkEncoder::script_get_defaults);
+	ClassDB::bind_method(D_METHOD("are_different", "buffer_a", "buffer_b"), &InputNetworkEncoder::script_are_different);
+	ClassDB::bind_method(D_METHOD("count_size", "buffer"), &InputNetworkEncoder::script_count_size);
+}
+
+uint32_t InputNetworkEncoder::register_input(
+		const StringName &p_name,
+		const Variant &p_default_value,
+		DataBuffer::DataType p_type,
+		DataBuffer::CompressionLevel p_compression_level,
+		real_t p_comparison_floating_point_precision) {
+	switch (p_type) {
+		case DataBuffer::DATA_TYPE_BOOL:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::BOOL, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `BOOL` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_INT:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::INT, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `INT` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_REAL:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::REAL, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `REAL` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_POSITIVE_UNIT_REAL:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::REAL, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `REAL` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_UNIT_REAL:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::REAL, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `REAL` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_VECTOR2:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::VECTOR2, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `Vector2` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR2:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::VECTOR2, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `Vector2` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_VECTOR3:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::VECTOR3, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `Vector3` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR3:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::VECTOR3, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `Vector3` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_VARIANT:
+			/* No need to check variant, anything is accepted at this point.*/
+			break;
+	};
+
+	const uint32_t index = input_info.size();
+
+	input_info.resize(input_info.size() + 1);
+	input_info[index].name = p_name;
+	input_info[index].default_value = p_default_value;
+	input_info[index].data_type = p_type;
+	input_info[index].compression_level = p_compression_level;
+	input_info[index].comparison_floating_point_precision = p_comparison_floating_point_precision;
+
+	return index;
+}
+
+uint32_t InputNetworkEncoder::find_input_id(const StringName &p_name) const {
+	for (uint32_t i = 0; i < input_info.size(); i += 1) {
+		if (input_info[i].name == p_name) {
+			return i;
+		}
+	}
+	return INDEX_NONE;
+}
+
+const LocalVector<NetworkedInputInfo> &InputNetworkEncoder::get_input_info() const {
+	return input_info;
+}
+
+void InputNetworkEncoder::encode(const LocalVector<Variant> &p_input, DataBuffer &r_buffer) const {
+	for (uint32_t i = 0; i < input_info.size(); i += 1) {
+		const NetworkedInputInfo &info = input_info[i];
+
+		const bool is_default =
+				// If the input exist into the array.
+				i >= p_input.size() ||
+				// Use default if the variable type is different.
+				info.default_value.get_type() != p_input[i].get_type() ||
+				// Use default if the variable value is equal to default.
+				info.default_value == p_input[i];
+
+		if (info.default_value.get_type() != Variant::BOOL) {
+			r_buffer.add_bool(is_default);
+
+			if (!is_default) {
+				const Variant &pending_input = p_input[i];
+				switch (info.data_type) {
+					case DataBuffer::DATA_TYPE_BOOL:
+						CRASH_NOW_MSG("Boolean are handled differently. Thanks to the above IF this condition never occurs.");
+						break;
+					case DataBuffer::DATA_TYPE_INT:
+						r_buffer.add_int(pending_input.operator int(), info.compression_level);
+						break;
+					case DataBuffer::DATA_TYPE_REAL:
+						r_buffer.add_real(pending_input.operator real_t(), info.compression_level);
+						break;
+					case DataBuffer::DATA_TYPE_POSITIVE_UNIT_REAL:
+						r_buffer.add_positive_unit_real(pending_input.operator real_t(), info.compression_level);
+						break;
+					case DataBuffer::DATA_TYPE_UNIT_REAL:
+						r_buffer.add_unit_real(pending_input.operator real_t(), info.compression_level);
+						break;
+					case DataBuffer::DATA_TYPE_VECTOR2:
+						r_buffer.add_vector2(pending_input.operator Vector2(), info.compression_level);
+						break;
+					case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR2:
+						r_buffer.add_normalized_vector2(pending_input.operator Vector2(), info.compression_level);
+						break;
+					case DataBuffer::DATA_TYPE_VECTOR3:
+						r_buffer.add_vector3(pending_input.operator Vector3(), info.compression_level);
+						break;
+					case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR3:
+						r_buffer.add_normalized_vector3(pending_input.operator Vector3(), info.compression_level);
+						break;
+					case DataBuffer::DATA_TYPE_VARIANT:
+						r_buffer.add_variant(pending_input);
+						break;
+				};
+			}
+		} else {
+			// If the data is bool no need to set the default.
+			if (!is_default) {
+				r_buffer.add_bool(p_input[i].operator bool());
+			} else {
+				r_buffer.add_bool(info.default_value.operator bool());
+			}
+		}
+	}
+}
+
+void InputNetworkEncoder::decode(DataBuffer &p_buffer, LocalVector<Variant> &r_inputs) const {
+	if (r_inputs.size() < input_info.size()) {
+		r_inputs.resize(input_info.size());
+	}
+
+	for (uint32_t i = 0; i < input_info.size(); i += 1) {
+		const NetworkedInputInfo &info = input_info[i];
+
+		const bool is_bool = info.default_value.get_type() == Variant::BOOL;
+
+		bool is_default = false;
+		if (is_bool == false) {
+			is_default = p_buffer.read_bool();
+		}
+
+		if (is_default) {
+			r_inputs[i] = info.default_value;
+		} else {
+			switch (info.data_type) {
+				case DataBuffer::DATA_TYPE_BOOL:
+					r_inputs[i] = p_buffer.read_bool();
+					break;
+				case DataBuffer::DATA_TYPE_INT:
+					r_inputs[i] = p_buffer.read_int(info.compression_level);
+					break;
+				case DataBuffer::DATA_TYPE_REAL:
+					r_inputs[i] = p_buffer.read_real(info.compression_level);
+					break;
+				case DataBuffer::DATA_TYPE_POSITIVE_UNIT_REAL:
+					r_inputs[i] = p_buffer.read_positive_unit_real(info.compression_level);
+					break;
+				case DataBuffer::DATA_TYPE_UNIT_REAL:
+					r_inputs[i] = p_buffer.read_unit_real(info.compression_level);
+					break;
+				case DataBuffer::DATA_TYPE_VECTOR2:
+					r_inputs[i] = p_buffer.read_vector2(info.compression_level);
+					break;
+				case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR2:
+					r_inputs[i] = p_buffer.read_normalized_vector2(info.compression_level);
+					break;
+				case DataBuffer::DATA_TYPE_VECTOR3:
+					r_inputs[i] = p_buffer.read_vector3(info.compression_level);
+					break;
+				case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR3:
+					r_inputs[i] = p_buffer.read_normalized_vector3(info.compression_level);
+					break;
+				case DataBuffer::DATA_TYPE_VARIANT:
+					r_inputs[i] = p_buffer.read_variant();
+					break;
+			};
+		}
+	}
+}
+
+void InputNetworkEncoder::reset_inputs_to_defaults(LocalVector<Variant> &r_input) const {
+	const uint32_t size = r_input.size() < input_info.size() ? r_input.size() : input_info.size();
+
+	for (uint32_t i = 0; i < size; i += 1) {
+		r_input[i] = input_info[i].default_value;
+	}
+}
+
+bool InputNetworkEncoder::are_different(DataBuffer &p_buffer_A, DataBuffer &p_buffer_B) const {
+	for (uint32_t i = 0; i < input_info.size(); i += 1) {
+		const NetworkedInputInfo &info = input_info[i];
+
+		const bool is_bool = info.default_value.get_type() == Variant::BOOL;
+
+		bool is_default_A = false;
+		bool is_default_B = false;
+		if (is_bool == false) {
+			is_default_A = p_buffer_A.read_bool();
+			is_default_B = p_buffer_B.read_bool();
+		}
+
+		bool are_equals = true;
+		if (is_default_A && is_default_B) {
+			are_equals = true;
+		} else {
+			switch (info.data_type) {
+				case DataBuffer::DATA_TYPE_BOOL:
+					are_equals = p_buffer_A.read_bool() == p_buffer_B.read_bool();
+					break;
+				case DataBuffer::DATA_TYPE_INT:
+					are_equals = Math::is_equal_approx(p_buffer_A.read_int(info.compression_level), p_buffer_B.read_int(info.compression_level), info.comparison_floating_point_precision);
+					break;
+				case DataBuffer::DATA_TYPE_REAL:
+					are_equals = Math::is_equal_approx(static_cast<real_t>(p_buffer_A.read_real(info.compression_level)), static_cast<real_t>(p_buffer_B.read_real(info.compression_level)), info.comparison_floating_point_precision);
+					break;
+				case DataBuffer::DATA_TYPE_POSITIVE_UNIT_REAL:
+					are_equals = Math::is_equal_approx(p_buffer_A.read_positive_unit_real(info.compression_level), p_buffer_B.read_positive_unit_real(info.compression_level), info.comparison_floating_point_precision);
+					break;
+				case DataBuffer::DATA_TYPE_UNIT_REAL:
+					are_equals = Math::is_equal_approx(p_buffer_A.read_unit_real(info.compression_level), p_buffer_B.read_unit_real(info.compression_level), info.comparison_floating_point_precision);
+					break;
+				case DataBuffer::DATA_TYPE_VECTOR2:
+					are_equals = SceneSynchronizer::compare(p_buffer_A.read_vector2(info.compression_level), p_buffer_B.read_vector2(info.compression_level), info.comparison_floating_point_precision);
+					break;
+				case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR2:
+					are_equals = SceneSynchronizer::compare(p_buffer_A.read_normalized_vector2(info.compression_level), p_buffer_B.read_normalized_vector2(info.compression_level), info.comparison_floating_point_precision);
+					break;
+				case DataBuffer::DATA_TYPE_VECTOR3:
+					are_equals = SceneSynchronizer::compare(p_buffer_A.read_vector3(info.compression_level), p_buffer_B.read_vector3(info.compression_level), info.comparison_floating_point_precision);
+					break;
+				case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR3:
+					are_equals = SceneSynchronizer::compare(p_buffer_A.read_normalized_vector3(info.compression_level), p_buffer_B.read_normalized_vector3(info.compression_level), info.comparison_floating_point_precision);
+					break;
+				case DataBuffer::DATA_TYPE_VARIANT:
+					are_equals = SceneSynchronizer::compare(p_buffer_A.read_variant(), p_buffer_B.read_variant(), info.comparison_floating_point_precision);
+					break;
+			};
+		}
+
+		if (!are_equals) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+uint32_t InputNetworkEncoder::count_size(DataBuffer &p_buffer) const {
+	int size = 0;
+	for (uint32_t i = 0; i < input_info.size(); i += 1) {
+		const NetworkedInputInfo &info = input_info[i];
+
+		const bool is_bool = info.default_value.get_type() == Variant::BOOL;
+
+		if (is_bool == false) {
+			size += p_buffer.read_bool_size();
+		}
+
+		switch (info.data_type) {
+			case DataBuffer::DATA_TYPE_BOOL:
+				size += p_buffer.read_bool_size();
+				break;
+			case DataBuffer::DATA_TYPE_INT:
+				size += p_buffer.read_int_size(info.compression_level);
+				break;
+			case DataBuffer::DATA_TYPE_REAL:
+				size += p_buffer.read_real_size(info.compression_level);
+				break;
+			case DataBuffer::DATA_TYPE_POSITIVE_UNIT_REAL:
+				size += p_buffer.read_positive_unit_real_size(info.compression_level);
+				break;
+			case DataBuffer::DATA_TYPE_UNIT_REAL:
+				size += p_buffer.read_unit_real_size(info.compression_level);
+				break;
+			case DataBuffer::DATA_TYPE_VECTOR2:
+				size += p_buffer.read_vector2_size(info.compression_level);
+				break;
+			case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR2:
+				size += p_buffer.read_normalized_vector2_size(info.compression_level);
+				break;
+			case DataBuffer::DATA_TYPE_VECTOR3:
+				size += p_buffer.read_vector3_size(info.compression_level);
+				break;
+			case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR3:
+				size += p_buffer.read_normalized_vector3_size(info.compression_level);
+				break;
+			case DataBuffer::DATA_TYPE_VARIANT:
+				size += p_buffer.read_variant_size();
+				break;
+		};
+	}
+
+	return size;
+}
+
+void InputNetworkEncoder::script_encode(const Array &p_inputs, Object *r_buffer) const {
+	ERR_FAIL_COND(r_buffer == nullptr);
+	DataBuffer *db = Object::cast_to<DataBuffer>(r_buffer);
+	ERR_FAIL_COND(db == nullptr);
+
+	LocalVector<Variant> inputs;
+	inputs.resize(p_inputs.size());
+	for (int i = 0; i < p_inputs.size(); i += 1) {
+		inputs[i] = p_inputs[i];
+	}
+
+	encode(inputs, *db);
+}
+
+Array InputNetworkEncoder::script_decode(Object *p_buffer) const {
+	ERR_FAIL_COND_V(p_buffer == nullptr, Array());
+	DataBuffer *db = Object::cast_to<DataBuffer>(p_buffer);
+	ERR_FAIL_COND_V(db == nullptr, Array());
+
+	LocalVector<Variant> inputs;
+	decode(*db, inputs);
+
+	Array out;
+	out.resize(inputs.size());
+	for (uint32_t i = 0; i < inputs.size(); i += 1) {
+		out[i] = inputs[i];
+	}
+	return out;
+}
+
+Array InputNetworkEncoder::script_get_defaults() const {
+	LocalVector<Variant> inputs;
+	inputs.resize(input_info.size());
+
+	reset_inputs_to_defaults(inputs);
+
+	Array out;
+	out.resize(inputs.size());
+	for (uint32_t i = 0; i < inputs.size(); i += 1) {
+		out[i] = inputs[i];
+	}
+	return out;
+}
+
+bool InputNetworkEncoder::script_are_different(Object *p_buffer_A, Object *p_buffer_B) const {
+	ERR_FAIL_COND_V(p_buffer_A == nullptr, true);
+	DataBuffer *db_A = Object::cast_to<DataBuffer>(p_buffer_A);
+	ERR_FAIL_COND_V(db_A == nullptr, false);
+
+	ERR_FAIL_COND_V(p_buffer_B == nullptr, true);
+	DataBuffer *db_B = Object::cast_to<DataBuffer>(p_buffer_B);
+	ERR_FAIL_COND_V(db_B == nullptr, true);
+
+	return are_different(*db_A, *db_B);
+}
+
+uint32_t InputNetworkEncoder::script_count_size(Object *p_buffer) const {
+	ERR_FAIL_COND_V(p_buffer == nullptr, 0);
+	DataBuffer *db = Object::cast_to<DataBuffer>(p_buffer);
+	ERR_FAIL_COND_V(db == nullptr, 0);
+
+	return count_size(*db);
+}

--- a/input_network_encoder.h
+++ b/input_network_encoder.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "core/local_vector.h"
+#include "core/resource.h"
+#include "core/variant.h"
+#include "network_synchronizer/data_buffer.h"
+
+struct NetworkedInputInfo {
+	StringName name;
+	Variant default_value;
+	uint32_t index;
+	DataBuffer::DataType data_type;
+	DataBuffer::CompressionLevel compression_level;
+	real_t comparison_floating_point_precision;
+};
+
+class InputNetworkEncoder : public Resource {
+	GDCLASS(InputNetworkEncoder, Resource)
+
+public:
+	constexpr static uint32_t INDEX_NONE = UINT32_MAX;
+
+private:
+	LocalVector<NetworkedInputInfo> input_info;
+
+protected:
+	static void _bind_methods();
+
+public:
+	uint32_t register_input(
+			const StringName &p_name,
+			const Variant &p_default_value,
+			DataBuffer::DataType p_type,
+			DataBuffer::CompressionLevel p_compression_level,
+			real_t p_comparison_floating_point_precision = CMP_EPSILON);
+
+	uint32_t find_input_id(const StringName &p_name) const;
+	const LocalVector<NetworkedInputInfo> &get_input_info() const;
+
+	void encode(const LocalVector<Variant> &p_inputs, DataBuffer &r_buffer) const;
+	void decode(DataBuffer &p_buffer, LocalVector<Variant> &r_inputs) const;
+	void reset_inputs_to_defaults(LocalVector<Variant> &r_inputs) const;
+	bool are_different(DataBuffer &p_buffer_A, DataBuffer &p_buffer_B) const;
+	uint32_t count_size(DataBuffer &p_buffer) const;
+
+	void script_encode(const Array &p_inputs, Object *r_buffer) const;
+	Array script_decode(Object *p_buffer) const;
+	Array script_get_defaults() const;
+	bool script_are_different(Object *p_buffer_A, Object *p_buffer_B) const;
+	uint32_t script_count_size(Object *p_buffer) const;
+};

--- a/networked_controller.cpp
+++ b/networked_controller.cpp
@@ -194,13 +194,12 @@ void NetworkedController::set_server_controlled(bool p_server_controlled) {
 			// Tell the client to do the switch too.
 			if (get_network_master() != 1) {
 				rpc_id(
-					get_network_master(),
-					SNAME("_rpc_set_server_controlled"),
-					server_controlled);
+						get_network_master(),
+						SNAME("_rpc_set_server_controlled"),
+						server_controlled);
 			} else {
 				NET_DEBUG_WARN("The node is owned by the server, there is no client that can control it; please assign the proper authority.");
 			}
-			
 
 		} else if (is_player_controller() || is_doll_controller()) {
 			NET_DEBUG_WARN("You should never call the function `set_server_controlled` on the client, this has an effect only if called on the server.");
@@ -222,19 +221,19 @@ void NetworkedController::set_server_controlled(bool p_server_controlled) {
 	}
 
 #ifdef DEBUG_ENABLED
-	if(has_method("_collect_inputs") == false && server_controlled == false) {
+	if (has_method("_collect_inputs") == false && server_controlled == false) {
 		WARN_PRINT("In your script you must inherit the virtual method `_collect_inputs` to correctly use the `NetworkedController`.");
 	}
-	
-	if(has_method("_controller_process") == false && server_controlled == false) {
+
+	if (has_method("_controller_process") == false && server_controlled == false) {
 		WARN_PRINT("In your script you must inherit the virtual method `_controller_process` to correctly use the `NetworkedController`.");
 	}
 
-	if(has_method("_are_inputs_different") == false && server_controlled == false) {
+	if (has_method("_are_inputs_different") == false && server_controlled == false) {
 		WARN_PRINT("In your script you must inherit the virtual method `_are_inputs_different` to correctly use the `NetworkedController`.");
 	}
 
-	if(has_method("_count_input_size") == false && server_controlled == false) {
+	if (has_method("_count_input_size") == false && server_controlled == false) {
 		WARN_PRINT("In your script you must inherit the virtual method `_count_input_size` to correctly use the `NetworkedController`.");
 	}
 #endif
@@ -436,6 +435,60 @@ void NetworkedController::pause_notify_dolls() {
 	}
 }
 
+void NetworkedController::validate_script_implementation() {
+	ERR_FAIL_COND_MSG(has_method("_collect_inputs") == false && server_controlled == false, "In your script you must inherit the virtual method `_collect_inputs` to correctly use the `NetworkedController`.");
+	ERR_FAIL_COND_MSG(has_method("_controller_process") == false && server_controlled == false, "In your script you must inherit the virtual method `_controller_process` to correctly use the `NetworkedController`.");
+	ERR_FAIL_COND_MSG(has_method("_are_inputs_different") == false && server_controlled == false, "In your script you must inherit the virtual method `_are_inputs_different` to correctly use the `NetworkedController`.");
+	ERR_FAIL_COND_MSG(has_method("_count_input_size") == false && server_controlled == false, "In your script you must inherit the virtual method `_count_input_size` to correctly use the `NetworkedController`.");
+	ERR_FAIL_COND_MSG(has_method("_collect_epoch_data") == false, "In your script you must inherit the virtual method `_collect_epoch_data` to correctly use the `NetworkedController`.");
+	ERR_FAIL_COND_MSG(has_method("_setup_interpolator") == false, "In your script you must inherit the virtual method `_setup_interpolator` to correctly use the `NetworkedController`.");
+	ERR_FAIL_COND_MSG(has_method("_parse_epoch_data") == false, "In your script you must inherit the virtual method `_parse_epoch_data` to correctly use the `NetworkedController`.");
+	ERR_FAIL_COND_MSG(has_method("_apply_epoch") == false, "In your script you must inherit the virtual method `_apply_epoch` to correctly use the `NetworkedController`.");
+}
+
+void NetworkedController::native_collect_inputs(real_t p_delta, DataBuffer &r_buffer) {
+	call(
+			SNAME("_collect_inputs"),
+			p_delta,
+			&r_buffer);
+}
+
+void NetworkedController::native_controller_process(real_t p_delta, DataBuffer &p_buffer) {
+	call(
+			SNAME("_controller_process"),
+			p_delta,
+			&p_buffer);
+}
+
+bool NetworkedController::native_are_inputs_different(DataBuffer &p_buffer_A, DataBuffer &p_buffer_B) {
+	return call(SNAME("_are_inputs_different"), &p_buffer_A, &p_buffer_B);
+}
+
+uint32_t NetworkedController::native_count_input_size(DataBuffer &p_buffer) {
+	return call(SNAME("_count_input_size"), &p_buffer);
+}
+
+void NetworkedController::native_collect_epoch_data(DataBuffer &r_buffer) {
+	call(SNAME("_collect_epoch_data"), &r_buffer);
+}
+
+void NetworkedController::native_setup_interpolator(Interpolator &r_interpolator) {
+	call(
+			SNAME("_setup_interpolator"),
+			&r_interpolator);
+}
+
+void NetworkedController::native_parse_epoch_data(Interpolator &p_interpolator, DataBuffer &r_buffer) {
+	call(SNAME("_parse_epoch_data"), &p_interpolator, &r_buffer);
+}
+
+void NetworkedController::native_apply_epoch(real_t p_delta, Vector<Variant> p_epoch_data) {
+	call(
+			SNAME("_apply_epoch"),
+			p_delta,
+			p_epoch_data);
+}
+
 bool NetworkedController::process_instant(int p_i, real_t p_delta) {
 	ERR_FAIL_COND_V_MSG(is_player_controller() == false, false, "Can be executed only on player controllers.");
 	return static_cast<PlayerController *>(controller)->process_instant(p_i, p_delta);
@@ -598,14 +651,7 @@ void NetworkedController::_notification(int p_what) {
 				return;
 			}
 
-			ERR_FAIL_COND_MSG(has_method("_collect_inputs") == false && server_controlled == false, "In your script you must inherit the virtual method `_collect_inputs` to correctly use the `NetworkedController`.");
-			ERR_FAIL_COND_MSG(has_method("_controller_process") == false && server_controlled == false, "In your script you must inherit the virtual method `_controller_process` to correctly use the `NetworkedController`.");
-			ERR_FAIL_COND_MSG(has_method("_are_inputs_different") == false && server_controlled == false, "In your script you must inherit the virtual method `_are_inputs_different` to correctly use the `NetworkedController`.");
-			ERR_FAIL_COND_MSG(has_method("_count_input_size") == false && server_controlled == false, "In your script you must inherit the virtual method `_count_input_size` to correctly use the `NetworkedController`.");
-			ERR_FAIL_COND_MSG(has_method("_collect_epoch_data") == false, "In your script you must inherit the virtual method `_collect_epoch_data` to correctly use the `NetworkedController`.");
-			ERR_FAIL_COND_MSG(has_method("_setup_interpolator") == false, "In your script you must inherit the virtual method `_setup_interpolator` to correctly use the `NetworkedController`.");
-			ERR_FAIL_COND_MSG(has_method("_parse_epoch_data") == false, "In your script you must inherit the virtual method `_parse_epoch_data` to correctly use the `NetworkedController`.");
-			ERR_FAIL_COND_MSG(has_method("_apply_epoch") == false, "In your script you must inherit the virtual method `_apply_epoch` to correctly use the `NetworkedController`.");
+			validate_script_implementation();
 
 		} break;
 #endif
@@ -634,10 +680,9 @@ void ServerController::process(real_t p_delta) {
 
 	node->get_inputs_buffer_mut().begin_read();
 	node->get_inputs_buffer_mut().seek(METADATA_SIZE);
-	node->call(
-			SNAME("_controller_process"),
+	node->native_controller_process(
 			p_delta,
-			&node->get_inputs_buffer_mut());
+			node->get_inputs_buffer_mut());
 
 	doll_sync(p_delta);
 
@@ -761,7 +806,7 @@ void ServerController::receive_inputs(const Vector<uint8_t> &p_data) {
 		// Read metadata
 		const bool has_data = pir.read_bool();
 
-		const int input_size_in_bits = (has_data ? int(node->call(SNAME("_count_input_size"), &pir)) : 0) + METADATA_SIZE;
+		const int input_size_in_bits = (has_data ? int(node->native_count_input_size(pir)) : 0) + METADATA_SIZE;
 		// Pad to 8 bits.
 		const int input_size_padded =
 				Math::ceil((static_cast<float>(input_size_in_bits)) / 8.0);
@@ -944,7 +989,7 @@ bool ServerController::fetch_next_input(real_t p_delta) {
 						pir_B.begin_read();
 						pir_B.seek(METADATA_SIZE);
 
-						const bool is_meaningful = node->call(SNAME("_are_inputs_different"), &pir_A, &pir_B);
+						const bool is_meaningful = node->native_are_inputs_different(pir_A, pir_B);
 						if (is_meaningful) {
 							break;
 						}
@@ -1012,7 +1057,7 @@ void ServerController::doll_sync(real_t p_delta) {
 			if (epoch_state_collected == false) {
 				epoch_state_data_cache.begin_write(0);
 				epoch_state_data_cache.add_int(epoch, DataBuffer::COMPRESSION_LEVEL_1);
-				node->call(SNAME("_collect_epoch_data"), &epoch_state_data_cache);
+				node->native_collect_epoch_data(epoch_state_data_cache);
 				epoch_state_data_cache.dry();
 				epoch_state_collected = true;
 			}
@@ -1172,7 +1217,7 @@ int AutonomousServerController::get_inputs_count() const {
 bool AutonomousServerController::fetch_next_input(real_t p_delta) {
 	node->get_inputs_buffer_mut().begin_write(METADATA_SIZE);
 	node->get_inputs_buffer_mut().seek(METADATA_SIZE);
-	node->call(SNAME("_collect_inputs"), p_delta, &node->get_inputs_buffer_mut());
+	node->native_collect_inputs(p_delta, node->get_inputs_buffer_mut());
 	node->get_inputs_buffer_mut().dry();
 
 	if (unlikely(current_input_buffer_id == UINT32_MAX)) {
@@ -1216,7 +1261,7 @@ void PlayerController::process(real_t p_delta) {
 		node->get_inputs_buffer_mut().begin_write(METADATA_SIZE);
 
 		node->get_inputs_buffer_mut().seek(METADATA_SIZE);
-		node->call(SNAME("_collect_inputs"), p_delta, &node->get_inputs_buffer_mut());
+		node->native_collect_inputs(p_delta, node->get_inputs_buffer_mut());
 
 		// Set metadata data.
 		node->get_inputs_buffer_mut().seek(0);
@@ -1236,7 +1281,7 @@ void PlayerController::process(real_t p_delta) {
 
 	// The physics process is always emitted, because we still need to simulate
 	// the character motion even if we don't store the player inputs.
-	node->call(SNAME("_controller_process"), p_delta, &node->get_inputs_buffer());
+	node->native_controller_process(p_delta, node->get_inputs_buffer_mut());
 
 	node->player_set_has_new_input(false);
 	if (accept_new_inputs) {
@@ -1321,7 +1366,7 @@ bool PlayerController::process_instant(int p_i, real_t p_delta) {
 		ib.shrink_to(METADATA_SIZE, frames_snapshot[i].buffer_size_bit - METADATA_SIZE);
 		ib.begin_read();
 		ib.seek(METADATA_SIZE);
-		node->call(SNAME("_controller_process"), p_delta, &ib);
+		node->native_controller_process(p_delta, ib);
 		return (i + 1) < frames_snapshot.size();
 	} else {
 		return false;
@@ -1396,7 +1441,7 @@ void PlayerController::send_frame_input_buffer_to_server() {
 					pir_B.begin_read();
 					pir_B.seek(METADATA_SIZE);
 
-					const bool are_different = node->call(SNAME("_are_inputs_different"), &pir_A, &pir_B);
+					const bool are_different = node->native_are_inputs_different(pir_A, pir_B);
 					is_similar = are_different == false;
 
 				} else if (frames_snapshot[i].similarity == previous_input_similarity) {
@@ -1487,9 +1532,7 @@ DollController::DollController(NetworkedController *p_node) :
 
 void DollController::ready() {
 	interpolator.reset();
-	node->call(
-			SNAME("_setup_interpolator"),
-			&interpolator);
+	node->native_setup_interpolator(interpolator);
 	interpolator.terminate_init();
 }
 
@@ -1502,8 +1545,7 @@ void DollController::process(real_t p_delta) {
 	}
 
 	const real_t fractional_part = advancing_epoch;
-	node->call(
-			SNAME("_apply_epoch"),
+	node->native_apply_epoch(
 			p_delta,
 			interpolator.pop_epoch(frame_epoch, fractional_part));
 }
@@ -1611,7 +1653,7 @@ uint32_t DollController::receive_epoch(const Vector<uint8_t> &p_data) {
 	}
 
 	interpolator.begin_write(epoch);
-	node->call(SNAME("_parse_epoch_data"), &interpolator, &buffer);
+	node->native_parse_epoch_data(interpolator, buffer);
 	interpolator.end_write();
 
 	return epoch;
@@ -1704,10 +1746,10 @@ NoNetController::NoNetController(NetworkedController *p_node) :
 
 void NoNetController::process(real_t p_delta) {
 	node->get_inputs_buffer_mut().begin_write(0); // No need of meta in this case.
-	node->call(SNAME("_collect_inputs"), p_delta, &node->get_inputs_buffer_mut());
+	node->native_collect_inputs(p_delta, node->get_inputs_buffer_mut());
 	node->get_inputs_buffer_mut().dry();
 	node->get_inputs_buffer_mut().begin_read();
-	node->call(SNAME("_controller_process"), p_delta, &node->get_inputs_buffer_mut());
+	node->native_controller_process(p_delta, node->get_inputs_buffer_mut());
 	frame_id += 1;
 }
 

--- a/networked_controller.h
+++ b/networked_controller.h
@@ -312,6 +312,16 @@ public:
 	void set_doll_peer_active(int p_peer_id, bool p_active);
 	void pause_notify_dolls();
 
+	virtual void validate_script_implementation();
+	virtual void native_collect_inputs(real_t p_delta, DataBuffer &r_buffer);
+	virtual void native_controller_process(real_t p_delta, DataBuffer &p_buffer);
+	virtual bool native_are_inputs_different(DataBuffer &p_buffer_A, DataBuffer &p_buffer_B);
+	virtual uint32_t native_count_input_size(DataBuffer &p_buffer);
+	virtual void native_collect_epoch_data(DataBuffer &r_buffer);
+	virtual void native_setup_interpolator(Interpolator &r_interpolator);
+	virtual void native_parse_epoch_data(Interpolator &p_interpolator, DataBuffer &r_buffer);
+	virtual void native_apply_epoch(real_t p_delta, Vector<Variant> p_epoch_data);
+
 	bool process_instant(int p_i, real_t p_delta);
 
 	/// Returns the server controller or nullptr if this is not a server.


### PR DESCRIPTION
This commit add support to implement the NetwokedController class from C++;
also it add the InputNetworkEncoder that can be used to simplify the
character controller implementation.

```c++
// Usually called into the constructor, or during the controller
// initialization. Registers the inputs encoded by `input_encoder`.
uint32_t input_id = input_encoder->register_input(
	StringName("move"),
	Vector2(), // Default
	DataBuffer::DATA_TYPE_NORMALIZED_VECTOR2,
	DataBuffer::COMPRESSION_LEVEL_2);

// Usually this is called from `collect_inputs()`.
// It encodes the input_array into the buffer, according to the
// registered inputs.
input_encoder->encode(input_array, r_buffer);

// Usually this is called from `controller_process`.
// It decodes the buffer and put the inputs inside the `input_array`.
input_encoder->decode(p_buffer, input_array);

// Usually this is called from `are_inputs_different`.
input_encoder->are_different(p_buffer_a, p_buffer_b);

// Usually this is called from `count_input_size`.
input_encoder->count_size(p_buffer);
```