### PR TITLE
Add native code support & InputNetowkEncoder.

### DIFF
--- a/data_buffer.cpp
+++ b/data_buffer.cpp
@@ -644,6 +644,11 @@ void DataBuffer::skip_real(CompressionLevel p_compression) {
 	skip(bits);
 }
 
+void DataBuffer::skip_positive_unit_real(CompressionLevel p_compression) {
+	const int bits = get_positive_unit_real_size(p_compression);
+	skip(bits);
+}
+
 void DataBuffer::skip_unit_real(CompressionLevel p_compression) {
 	const int bits = get_unit_real_size(p_compression);
 	skip(bits);
@@ -681,6 +686,10 @@ int DataBuffer::get_real_size(CompressionLevel p_compression) const {
 	return DataBuffer::get_bit_taken(DATA_TYPE_REAL, p_compression);
 }
 
+int DataBuffer::get_positive_unit_real_size(CompressionLevel p_compression) const {
+	return DataBuffer::get_bit_taken(DATA_TYPE_POSITIVE_UNIT_REAL, p_compression);
+}
+
 int DataBuffer::get_unit_real_size(CompressionLevel p_compression) const {
 	return DataBuffer::get_bit_taken(DATA_TYPE_UNIT_REAL, p_compression);
 }
@@ -715,6 +724,12 @@ int DataBuffer::read_int_size(CompressionLevel p_compression) {
 
 int DataBuffer::read_real_size(CompressionLevel p_compression) {
 	const int bits = get_real_size(p_compression);
+	skip(bits);
+	return bits;
+}
+
+int DataBuffer::read_positive_unit_real_size(CompressionLevel p_compression) {
+	const int bits = get_positive_unit_real_size(p_compression);
 	skip(bits);
 	return bits;
 }
@@ -803,7 +818,7 @@ int DataBuffer::get_bit_taken(DataType p_data_type, CompressionLevel p_compressi
 		} break;
 		case DATA_TYPE_REAL: {
 			return get_mantissa_bits(p_compression) +
-				   get_exponent_bits(p_compression);
+					get_exponent_bits(p_compression);
 		} break;
 		case DATA_TYPE_POSITIVE_UNIT_REAL: {
 			switch (p_compression) {

--- a/data_buffer.h
+++ b/data_buffer.h
@@ -294,6 +294,7 @@ public:
 	void skip_bool();
 	void skip_int(CompressionLevel p_compression);
 	void skip_real(CompressionLevel p_compression);
+	void skip_positive_unit_real(CompressionLevel p_compression);
 	void skip_unit_real(CompressionLevel p_compression);
 	void skip_vector2(CompressionLevel p_compression);
 	void skip_normalized_vector2(CompressionLevel p_compression);
@@ -305,6 +306,7 @@ public:
 	int get_bool_size() const;
 	int get_int_size(CompressionLevel p_compression) const;
 	int get_real_size(CompressionLevel p_compression) const;
+	int get_positive_unit_real_size(CompressionLevel p_compression) const;
 	int get_unit_real_size(CompressionLevel p_compression) const;
 	int get_vector2_size(CompressionLevel p_compression) const;
 	int get_normalized_vector2_size(CompressionLevel p_compression) const;
@@ -316,6 +318,7 @@ public:
 	int read_bool_size();
 	int read_int_size(CompressionLevel p_compression);
 	int read_real_size(CompressionLevel p_compression);
+	int read_positive_unit_real_size(CompressionLevel p_compression);
 	int read_unit_real_size(CompressionLevel p_compression);
 	int read_vector2_size(CompressionLevel p_compression);
 	int read_normalized_vector2_size(CompressionLevel p_compression);

--- a/input_network_encoder.cpp
+++ b/input_network_encoder.cpp
@@ -1,0 +1,371 @@
+#include "input_network_encoder.h"
+
+#include "scene_synchronizer.h"
+
+void InputNetworkEncoder::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("register_input", "name", "default_value", "type", "compression_level"), &InputNetworkEncoder::register_input);
+	ClassDB::bind_method(D_METHOD("find_input_id", "name"), &InputNetworkEncoder::find_input_id);
+	ClassDB::bind_method(D_METHOD("encode", "inputs", "buffer"), &InputNetworkEncoder::script_encode);
+	ClassDB::bind_method(D_METHOD("decode", "buffer", "inputs"), &InputNetworkEncoder::script_decode);
+	ClassDB::bind_method(D_METHOD("get_defaults"), &InputNetworkEncoder::script_get_defaults);
+	ClassDB::bind_method(D_METHOD("are_different", "buffer_a", "buffer_b"), &InputNetworkEncoder::script_are_different);
+	ClassDB::bind_method(D_METHOD("count_size", "buffer"), &InputNetworkEncoder::script_count_size);
+}
+
+uint32_t InputNetworkEncoder::register_input(
+		const StringName &p_name,
+		const Variant &p_default_value,
+		DataBuffer::DataType p_type,
+		DataBuffer::CompressionLevel p_compression_level,
+		real_t p_comparison_floating_point_precision) {
+	switch (p_type) {
+		case DataBuffer::DATA_TYPE_BOOL:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::BOOL, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `BOOL` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_INT:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::INT, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `INT` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_REAL:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::FLOAT, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `REAL` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_POSITIVE_UNIT_REAL:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::FLOAT, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `REAL` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_UNIT_REAL:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::FLOAT, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `REAL` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_VECTOR2:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::VECTOR2, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `Vector2` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR2:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::VECTOR2, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `Vector2` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_VECTOR3:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::VECTOR3, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `Vector3` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR3:
+			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::VECTOR3, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `Vector3` but the default parameter is " + itos(p_default_value.get_type()));
+			break;
+		case DataBuffer::DATA_TYPE_VARIANT:
+			/* No need to check variant, anything is accepted at this point.*/
+			break;
+	};
+
+	const uint32_t index = input_info.size();
+
+	input_info.resize(input_info.size() + 1);
+	input_info[index].name = p_name;
+	input_info[index].default_value = p_default_value;
+	input_info[index].data_type = p_type;
+	input_info[index].compression_level = p_compression_level;
+	input_info[index].comparison_floating_point_precision = p_comparison_floating_point_precision;
+
+	return index;
+}
+
+uint32_t InputNetworkEncoder::find_input_id(const StringName &p_name) const {
+	for (uint32_t i = 0; i < input_info.size(); i += 1) {
+		if (input_info[i].name == p_name) {
+			return i;
+		}
+	}
+	return INDEX_NONE;
+}
+
+const LocalVector<NetworkedInputInfo> &InputNetworkEncoder::get_input_info() const {
+	return input_info;
+}
+
+void InputNetworkEncoder::encode(const LocalVector<Variant> &p_input, DataBuffer &r_buffer) const {
+	for (uint32_t i = 0; i < input_info.size(); i += 1) {
+		const NetworkedInputInfo &info = input_info[i];
+
+		const bool is_default =
+				// If the input exist into the array.
+				i >= p_input.size() ||
+				// Use default if the variable type is different.
+				info.default_value.get_type() != p_input[i].get_type() ||
+				// Use default if the variable value is equal to default.
+				info.default_value == p_input[i];
+
+		if (info.default_value.get_type() != Variant::BOOL) {
+			r_buffer.add_bool(is_default);
+
+			if (!is_default) {
+				const Variant &pending_input = p_input[i];
+				switch (info.data_type) {
+					case DataBuffer::DATA_TYPE_BOOL:
+						CRASH_NOW_MSG("Boolean are handled differently. Thanks to the above IF this condition never occurs.");
+						break;
+					case DataBuffer::DATA_TYPE_INT:
+						r_buffer.add_int(pending_input.operator int(), info.compression_level);
+						break;
+					case DataBuffer::DATA_TYPE_REAL:
+						r_buffer.add_real(pending_input.operator real_t(), info.compression_level);
+						break;
+					case DataBuffer::DATA_TYPE_POSITIVE_UNIT_REAL:
+						r_buffer.add_positive_unit_real(pending_input.operator real_t(), info.compression_level);
+						break;
+					case DataBuffer::DATA_TYPE_UNIT_REAL:
+						r_buffer.add_unit_real(pending_input.operator real_t(), info.compression_level);
+						break;
+					case DataBuffer::DATA_TYPE_VECTOR2:
+						r_buffer.add_vector2(pending_input.operator Vector2(), info.compression_level);
+						break;
+					case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR2:
+						r_buffer.add_normalized_vector2(pending_input.operator Vector2(), info.compression_level);
+						break;
+					case DataBuffer::DATA_TYPE_VECTOR3:
+						r_buffer.add_vector3(pending_input.operator Vector3(), info.compression_level);
+						break;
+					case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR3:
+						r_buffer.add_normalized_vector3(pending_input.operator Vector3(), info.compression_level);
+						break;
+					case DataBuffer::DATA_TYPE_VARIANT:
+						r_buffer.add_variant(pending_input);
+						break;
+				};
+			}
+		} else {
+			// If the data is bool no need to set the default.
+			if (!is_default) {
+				r_buffer.add_bool(p_input[i].operator bool());
+			} else {
+				r_buffer.add_bool(info.default_value.operator bool());
+			}
+		}
+	}
+}
+
+void InputNetworkEncoder::decode(DataBuffer &p_buffer, LocalVector<Variant> &r_inputs) const {
+	if (r_inputs.size() < input_info.size()) {
+		r_inputs.resize(input_info.size());
+	}
+
+	for (uint32_t i = 0; i < input_info.size(); i += 1) {
+		const NetworkedInputInfo &info = input_info[i];
+
+		const bool is_bool = info.default_value.get_type() == Variant::BOOL;
+
+		bool is_default = false;
+		if (is_bool == false) {
+			is_default = p_buffer.read_bool();
+		}
+
+		if (is_default) {
+			r_inputs[i] = info.default_value;
+		} else {
+			switch (info.data_type) {
+				case DataBuffer::DATA_TYPE_BOOL:
+					r_inputs[i] = p_buffer.read_bool();
+					break;
+				case DataBuffer::DATA_TYPE_INT:
+					r_inputs[i] = p_buffer.read_int(info.compression_level);
+					break;
+				case DataBuffer::DATA_TYPE_REAL:
+					r_inputs[i] = p_buffer.read_real(info.compression_level);
+					break;
+				case DataBuffer::DATA_TYPE_POSITIVE_UNIT_REAL:
+					r_inputs[i] = p_buffer.read_positive_unit_real(info.compression_level);
+					break;
+				case DataBuffer::DATA_TYPE_UNIT_REAL:
+					r_inputs[i] = p_buffer.read_unit_real(info.compression_level);
+					break;
+				case DataBuffer::DATA_TYPE_VECTOR2:
+					r_inputs[i] = p_buffer.read_vector2(info.compression_level);
+					break;
+				case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR2:
+					r_inputs[i] = p_buffer.read_normalized_vector2(info.compression_level);
+					break;
+				case DataBuffer::DATA_TYPE_VECTOR3:
+					r_inputs[i] = p_buffer.read_vector3(info.compression_level);
+					break;
+				case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR3:
+					r_inputs[i] = p_buffer.read_normalized_vector3(info.compression_level);
+					break;
+				case DataBuffer::DATA_TYPE_VARIANT:
+					r_inputs[i] = p_buffer.read_variant();
+					break;
+			};
+		}
+	}
+}
+
+void InputNetworkEncoder::reset_inputs_to_defaults(LocalVector<Variant> &r_input) const {
+	const uint32_t size = r_input.size() < input_info.size() ? r_input.size() : input_info.size();
+
+	for (uint32_t i = 0; i < size; i += 1) {
+		r_input[i] = input_info[i].default_value;
+	}
+}
+
+bool InputNetworkEncoder::are_different(DataBuffer &p_buffer_A, DataBuffer &p_buffer_B) const {
+	for (uint32_t i = 0; i < input_info.size(); i += 1) {
+		const NetworkedInputInfo &info = input_info[i];
+
+		const bool is_bool = info.default_value.get_type() == Variant::BOOL;
+
+		bool is_default_A = false;
+		bool is_default_B = false;
+		if (is_bool == false) {
+			is_default_A = p_buffer_A.read_bool();
+			is_default_B = p_buffer_B.read_bool();
+		}
+
+		bool are_equals = true;
+		if (is_default_A && is_default_B) {
+			are_equals = true;
+		} else {
+			switch (info.data_type) {
+				case DataBuffer::DATA_TYPE_BOOL:
+					are_equals = p_buffer_A.read_bool() == p_buffer_B.read_bool();
+					break;
+				case DataBuffer::DATA_TYPE_INT:
+					are_equals = Math::is_equal_approx(p_buffer_A.read_int(info.compression_level), p_buffer_B.read_int(info.compression_level), info.comparison_floating_point_precision);
+					break;
+				case DataBuffer::DATA_TYPE_REAL:
+					are_equals = Math::is_equal_approx(static_cast<real_t>(p_buffer_A.read_real(info.compression_level)), static_cast<real_t>(p_buffer_B.read_real(info.compression_level)), info.comparison_floating_point_precision);
+					break;
+				case DataBuffer::DATA_TYPE_POSITIVE_UNIT_REAL:
+					are_equals = Math::is_equal_approx(p_buffer_A.read_positive_unit_real(info.compression_level), p_buffer_B.read_positive_unit_real(info.compression_level), info.comparison_floating_point_precision);
+					break;
+				case DataBuffer::DATA_TYPE_UNIT_REAL:
+					are_equals = Math::is_equal_approx(p_buffer_A.read_unit_real(info.compression_level), p_buffer_B.read_unit_real(info.compression_level), info.comparison_floating_point_precision);
+					break;
+				case DataBuffer::DATA_TYPE_VECTOR2:
+					are_equals = SceneSynchronizer::compare(p_buffer_A.read_vector2(info.compression_level), p_buffer_B.read_vector2(info.compression_level), info.comparison_floating_point_precision);
+					break;
+				case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR2:
+					are_equals = SceneSynchronizer::compare(p_buffer_A.read_normalized_vector2(info.compression_level), p_buffer_B.read_normalized_vector2(info.compression_level), info.comparison_floating_point_precision);
+					break;
+				case DataBuffer::DATA_TYPE_VECTOR3:
+					are_equals = SceneSynchronizer::compare(p_buffer_A.read_vector3(info.compression_level), p_buffer_B.read_vector3(info.compression_level), info.comparison_floating_point_precision);
+					break;
+				case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR3:
+					are_equals = SceneSynchronizer::compare(p_buffer_A.read_normalized_vector3(info.compression_level), p_buffer_B.read_normalized_vector3(info.compression_level), info.comparison_floating_point_precision);
+					break;
+				case DataBuffer::DATA_TYPE_VARIANT:
+					are_equals = SceneSynchronizer::compare(p_buffer_A.read_variant(), p_buffer_B.read_variant(), info.comparison_floating_point_precision);
+					break;
+			};
+		}
+
+		if (!are_equals) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+uint32_t InputNetworkEncoder::count_size(DataBuffer &p_buffer) const {
+	int size = 0;
+	for (uint32_t i = 0; i < input_info.size(); i += 1) {
+		const NetworkedInputInfo &info = input_info[i];
+
+		const bool is_bool = info.default_value.get_type() == Variant::BOOL;
+
+		if (is_bool == false) {
+			size += p_buffer.read_bool_size();
+		}
+
+		switch (info.data_type) {
+			case DataBuffer::DATA_TYPE_BOOL:
+				size += p_buffer.read_bool_size();
+				break;
+			case DataBuffer::DATA_TYPE_INT:
+				size += p_buffer.read_int_size(info.compression_level);
+				break;
+			case DataBuffer::DATA_TYPE_REAL:
+				size += p_buffer.read_real_size(info.compression_level);
+				break;
+			case DataBuffer::DATA_TYPE_POSITIVE_UNIT_REAL:
+				size += p_buffer.read_positive_unit_real_size(info.compression_level);
+				break;
+			case DataBuffer::DATA_TYPE_UNIT_REAL:
+				size += p_buffer.read_unit_real_size(info.compression_level);
+				break;
+			case DataBuffer::DATA_TYPE_VECTOR2:
+				size += p_buffer.read_vector2_size(info.compression_level);
+				break;
+			case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR2:
+				size += p_buffer.read_normalized_vector2_size(info.compression_level);
+				break;
+			case DataBuffer::DATA_TYPE_VECTOR3:
+				size += p_buffer.read_vector3_size(info.compression_level);
+				break;
+			case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR3:
+				size += p_buffer.read_normalized_vector3_size(info.compression_level);
+				break;
+			case DataBuffer::DATA_TYPE_VARIANT:
+				size += p_buffer.read_variant_size();
+				break;
+		};
+	}
+
+	return size;
+}
+
+void InputNetworkEncoder::script_encode(const Array &p_inputs, Object *r_buffer) const {
+	ERR_FAIL_COND(r_buffer == nullptr);
+	DataBuffer *db = Object::cast_to<DataBuffer>(r_buffer);
+	ERR_FAIL_COND(db == nullptr);
+
+	LocalVector<Variant> inputs;
+	inputs.resize(p_inputs.size());
+	for (int i = 0; i < p_inputs.size(); i += 1) {
+		inputs[i] = p_inputs[i];
+	}
+
+	encode(inputs, *db);
+}
+
+Array InputNetworkEncoder::script_decode(Object *p_buffer) const {
+	ERR_FAIL_COND_V(p_buffer == nullptr, Array());
+	DataBuffer *db = Object::cast_to<DataBuffer>(p_buffer);
+	ERR_FAIL_COND_V(db == nullptr, Array());
+
+	LocalVector<Variant> inputs;
+	decode(*db, inputs);
+
+	Array out;
+	out.resize(inputs.size());
+	for (uint32_t i = 0; i < inputs.size(); i += 1) {
+		out[i] = inputs[i];
+	}
+	return out;
+}
+
+Array InputNetworkEncoder::script_get_defaults() const {
+	LocalVector<Variant> inputs;
+	inputs.resize(input_info.size());
+
+	reset_inputs_to_defaults(inputs);
+
+	Array out;
+	out.resize(inputs.size());
+	for (uint32_t i = 0; i < inputs.size(); i += 1) {
+		out[i] = inputs[i];
+	}
+	return out;
+}
+
+bool InputNetworkEncoder::script_are_different(Object *p_buffer_A, Object *p_buffer_B) const {
+	ERR_FAIL_COND_V(p_buffer_A == nullptr, true);
+	DataBuffer *db_A = Object::cast_to<DataBuffer>(p_buffer_A);
+	ERR_FAIL_COND_V(db_A == nullptr, false);
+
+	ERR_FAIL_COND_V(p_buffer_B == nullptr, true);
+	DataBuffer *db_B = Object::cast_to<DataBuffer>(p_buffer_B);
+	ERR_FAIL_COND_V(db_B == nullptr, true);
+
+	return are_different(*db_A, *db_B);
+}
+
+uint32_t InputNetworkEncoder::script_count_size(Object *p_buffer) const {
+	ERR_FAIL_COND_V(p_buffer == nullptr, 0);
+	DataBuffer *db = Object::cast_to<DataBuffer>(p_buffer);
+	ERR_FAIL_COND_V(db == nullptr, 0);
+
+	return count_size(*db);
+}

--- a/input_network_encoder.h
+++ b/input_network_encoder.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "core/io/resource.h"
+#include "core/templates/local_vector.h"
+#include "core/variant/variant.h"
+#include "network_synchronizer/data_buffer.h"
+
+struct NetworkedInputInfo {
+	StringName name;
+	Variant default_value;
+	uint32_t index;
+	DataBuffer::DataType data_type;
+	DataBuffer::CompressionLevel compression_level;
+	real_t comparison_floating_point_precision;
+};
+
+class InputNetworkEncoder : public Resource {
+	GDCLASS(InputNetworkEncoder, Resource)
+
+public:
+	constexpr static uint32_t INDEX_NONE = UINT32_MAX;
+
+private:
+	LocalVector<NetworkedInputInfo> input_info;
+
+protected:
+	static void _bind_methods();
+
+public:
+	uint32_t register_input(
+			const StringName &p_name,
+			const Variant &p_default_value,
+			DataBuffer::DataType p_type,
+			DataBuffer::CompressionLevel p_compression_level,
+			real_t p_comparison_floating_point_precision = CMP_EPSILON);
+
+	uint32_t find_input_id(const StringName &p_name) const;
+	const LocalVector<NetworkedInputInfo> &get_input_info() const;
+
+	void encode(const LocalVector<Variant> &p_inputs, DataBuffer &r_buffer) const;
+	void decode(DataBuffer &p_buffer, LocalVector<Variant> &r_inputs) const;
+	void reset_inputs_to_defaults(LocalVector<Variant> &r_inputs) const;
+	bool are_different(DataBuffer &p_buffer_A, DataBuffer &p_buffer_B) const;
+	uint32_t count_size(DataBuffer &p_buffer) const;
+
+	void script_encode(const Array &p_inputs, Object *r_buffer) const;
+	Array script_decode(Object *p_buffer) const;
+	Array script_get_defaults() const;
+	bool script_are_different(Object *p_buffer_A, Object *p_buffer_B) const;
+	uint32_t script_count_size(Object *p_buffer) const;
+};

--- a/networked_controller.h
+++ b/networked_controller.h
@@ -83,12 +83,12 @@ public:
 	};
 
 	GDVIRTUAL2(_collect_inputs, real_t, DataBuffer *);
-	GDVIRTUAL2(_controller_process, real_t, const DataBuffer *);
-	GDVIRTUAL2R(bool, _are_inputs_different, const DataBuffer *, const DataBuffer *);
-	GDVIRTUAL1RC(int, _count_input_size, const DataBuffer *);
+	GDVIRTUAL2(_controller_process, real_t, DataBuffer *);
+	GDVIRTUAL2R(bool, _are_inputs_different, DataBuffer *, DataBuffer *);
+	GDVIRTUAL1RC(int, _count_input_size, DataBuffer *);
 	GDVIRTUAL1(_collect_epoch_data, DataBuffer *);
 	GDVIRTUAL1(_setup_interpolator, Interpolator *);
-	GDVIRTUAL2(_parse_epoch_data, Interpolator *, const DataBuffer *);
+	GDVIRTUAL2(_parse_epoch_data, Interpolator *, DataBuffer *);
 	GDVIRTUAL2(_apply_epoch, real_t, Array);
 
 private:
@@ -317,6 +317,16 @@ public:
 	void set_doll_collect_rate_factor(int p_peer, real_t p_factor);
 	void set_doll_peer_active(int p_peer_id, bool p_active);
 	void pause_notify_dolls();
+
+	virtual void validate_script_implementation();
+	virtual void native_collect_inputs(real_t p_delta, DataBuffer &r_buffer);
+	virtual void native_controller_process(real_t p_delta, DataBuffer &p_buffer);
+	virtual bool native_are_inputs_different(DataBuffer &p_buffer_A, DataBuffer &p_buffer_B);
+	virtual uint32_t native_count_input_size(DataBuffer &p_buffer);
+	virtual void native_collect_epoch_data(DataBuffer &r_buffer);
+	virtual void native_setup_interpolator(Interpolator &r_interpolator);
+	virtual void native_parse_epoch_data(Interpolator &p_interpolator, DataBuffer &r_buffer);
+	virtual void native_apply_epoch(real_t p_delta, const Array &p_epoch_data);
 
 	bool process_instant(int p_i, real_t p_delta);
 


### PR DESCRIPTION
> Port of: https://github.com/GodotNetworking/network_synchronizer/pull/15

This commit add support to implement the NetwokedController class from C++;
also it add the InputNetworkEncoder that can be used to simplify the
character controller implementation.

```c++
// Usually called into the constructor, or during the controller
// initialization. Registers the inputs encoded by `input_encoder`.
uint32_t input_id = input_encoder->register_input(
	StringName("move"),
	Vector2(), // Default
	DataBuffer::DATA_TYPE_NORMALIZED_VECTOR2,
	DataBuffer::COMPRESSION_LEVEL_2);

// Usually this is called from `collect_inputs()`.
// It encodes the input_array into the buffer, according to the
// registered inputs.
input_encoder->encode(input_array, r_buffer);

// Usually this is called from `controller_process`.
// It decodes the buffer and put the inputs inside the `input_array`.
input_encoder->decode(p_buffer, input_array);

// Usually this is called from `are_inputs_different`.
input_encoder->are_different(p_buffer_a, p_buffer_b);

// Usually this is called from `count_input_size`.
input_encoder->count_size(p_buffer);
```