### PR TITLE
Add *.obj to .gitignore and add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize EOL for all files that Git considers text files
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ data_*/
 # General c++ generated files
 *.lib
 *.o
+*.obj
 *.ox
 *.a
 *.ax
@@ -40,4 +41,3 @@ data_*/
 
 # CLion
 .idea/
-


### PR DESCRIPTION
This PR adds `*.obj` to the .gitignore and adds a .gitattributes file. These changes help with using this module on Windows. Before I was getting MSVC compilation artifacts showing up in Git.