### PR TITLE
Fix `NetUtility::NodeData` struct being forward declared as a class

### DIFF
--- a/net_action_processor.h
+++ b/net_action_processor.h
@@ -4,7 +4,7 @@
 #include "core/variant/array.h"
 
 namespace NetUtility {
-class NodeData;
+struct NodeData;
 };
 
 typedef uint32_t NetActionId;


### PR DESCRIPTION
It is defined as `struct NodeData {` in `net_utilities.h`, but this forward declaration did not match. This PR fixes it.

Classes and structs are not the same, and they are defined separately in MSVC.

```
modules/network_synchronizer/net_utilities.h:316:1: warning: 'NodeData' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
struct NodeData {
^
modules/network_synchronizer/net_action_processor.h:7:1: note: did you mean struct here?
class NodeData;
^~~~~
struct
```