### PR TITLE
Improved speedup mechanism.

### DIFF
--- a/net_utilities.cpp
+++ b/net_utilities.cpp
@@ -61,7 +61,7 @@ bool NetUtility::VarData::operator<(const VarData &p_other) const {
 	return id < p_other.id;
 }
 
-void NetUtility::NodeData::process(const real_t p_delta) const {
+void NetUtility::NodeData::process(const double p_delta) const {
 	const Variant var_delta = p_delta;
 	const Variant *fake_array_vars = &var_delta;
 

--- a/networked_controller.h
+++ b/networked_controller.h
@@ -117,11 +117,11 @@ private:
 	/// Amount of time an inputs is re-sent to each peer.
 	/// Resenging inputs is necessary because the packets may be lost since as
 	/// they are sent in an unreliable way.
-	int max_redundant_inputs = 5;
+	int max_redundant_inputs = 6;
 
 	/// Time in seconds between each `tick_speedup` that the server sends to the
-	/// client.
-	real_t tick_speedup_notification_delay = 0.33;
+	/// client. In ms.
+	int tick_speedup_notification_delay = 600;
 
 	/// The connection quality is established by watching the time passed
 	/// between each input is received.
@@ -133,22 +133,6 @@ private:
 	/// - Small values make the mechanism too sensible.
 	int network_traced_frames = 120;
 
-	/// Sensitivity to network oscillations. The value is in seconds and can be
-	/// used to establish the connection quality.
-	///
-	/// For each input, the time needed for its arrival is traced; the standard
-	/// deviation of these is divided by `net_sensitivity`: the result is
-	/// the connection quality.
-	///
-	/// The more the time needed for each batch to arrive is different the
-	/// bigger this value is: when this value approaches to
-	/// `net_sensitivity` (or even surpasses it) the bad the connection is.
-	///
-	/// The result is the `connection_poorness` that goes from 0 to 1 and is
-	/// used to decide the `optimal_frame_delay` that is interpolated between
-	/// `min_frames_delay` and `max_frames_delay`.
-	real_t net_sensitivity = 0.1;
-
 	/// The `ServerController` will try to keep a margin of error, so that
 	/// network oscillations doesn't leave the `ServerController` without
 	/// inputs.
@@ -156,12 +140,11 @@ private:
 	/// This margin of error is called `optimal_frame_delay` and it changes
 	/// depending on the connection health:
 	/// it can go from `min_frames_delay` to `max_frames_delay`.
-	int min_frames_delay = 1;
-	int max_frames_delay = 6;
+	int min_frames_delay = 0;
+	int max_frames_delay = 7;
 
-	/// Rate at which the tick speed changes, so the `optimal_frame_delay` is
-	/// matched.
-	real_t tick_acceleration = 2.0;
+	/// Amount of additional frames produced per second.
+	double tick_acceleration = 5.0;
 
 	/// The doll epoch send rate: in Hz (frames per seconds).
 	uint32_t doll_sync_rate = 30;
@@ -226,8 +209,8 @@ public:
 	void set_max_redundant_inputs(int p_max);
 	int get_max_redundant_inputs() const;
 
-	void set_tick_speedup_notification_delay(real_t p_delay);
-	real_t get_tick_speedup_notification_delay() const;
+	void set_tick_speedup_notification_delay(int p_delay_in_ms);
+	int get_tick_speedup_notification_delay() const;
 
 	void set_network_traced_frames(int p_size);
 	int get_network_traced_frames() const;
@@ -238,11 +221,8 @@ public:
 	void set_max_frames_delay(int p_val);
 	int get_max_frames_delay() const;
 
-	void set_net_sensitivity(real_t p_val);
-	real_t get_net_sensitivity() const;
-
-	void set_tick_acceleration(real_t p_acceleration);
-	real_t get_tick_acceleration() const;
+	void set_tick_acceleration(double p_acceleration);
+	double get_tick_acceleration() const;
 
 	void set_doll_epoch_collect_rate(int p_rate);
 	int get_doll_epoch_collect_rate() const;
@@ -279,7 +259,7 @@ public:
 	}
 
 	/// Returns the pretended delta used by the player.
-	real_t player_get_pretended_delta(uint32_t p_iterations_per_seconds) const;
+	real_t player_get_pretended_delta() const;
 
 	void mark_epoch_as_important();
 
@@ -288,12 +268,12 @@ public:
 	void pause_notify_dolls();
 
 	virtual void validate_script_implementation();
-	virtual void native_collect_inputs(real_t p_delta, DataBuffer &r_buffer);
-	virtual void native_controller_process(real_t p_delta, DataBuffer &p_buffer);
+	virtual void native_collect_inputs(double p_delta, DataBuffer &r_buffer);
+	virtual void native_controller_process(double p_delta, DataBuffer &p_buffer);
 	virtual bool native_are_inputs_different(DataBuffer &p_buffer_A, DataBuffer &p_buffer_B);
 	virtual uint32_t native_count_input_size(DataBuffer &p_buffer);
 	virtual void native_collect_epoch_data(DataBuffer &r_buffer);
-	virtual void native_apply_epoch(real_t p_delta, real_t p_interpolation_alpha, DataBuffer &p_past_buffer, DataBuffer &p_future_buffer);
+	virtual void native_apply_epoch(double p_delta, real_t p_interpolation_alpha, DataBuffer &p_past_buffer, DataBuffer &p_future_buffer);
 
 	bool process_instant(int p_i, real_t p_delta);
 
@@ -328,13 +308,13 @@ public:
 
 	/* On client rpc functions. */
 	void _rpc_set_server_controlled(bool p_server_controlled);
-	void _rpc_send_tick_additional_speed(const Vector<uint8_t> &p_data);
+	void _rpc_notify_fps_acceleration(const Vector<uint8_t> &p_data);
 
 	/* On puppet rpc functions. */
 	void _rpc_doll_notify_sync_pause(uint32_t p_epoch);
 	void _rpc_doll_send_epoch_batch(const Vector<uint8_t> &p_data);
 
-	void process(real_t p_delta);
+	void process(double p_delta);
 
 	void player_set_has_new_input(bool p_has);
 	bool player_has_new_input() const;
@@ -351,6 +331,8 @@ struct FrameSnapshot {
 	BitArray inputs_buffer;
 	uint32_t buffer_size_bit;
 	uint32_t similarity;
+	/// Local timestamp.
+	uint32_t received_timestamp;
 
 	bool operator==(const FrameSnapshot &p_other) const {
 		return p_other.id == id;
@@ -389,14 +371,14 @@ struct ServerController : public Controller {
 	uint32_t current_input_buffer_id = UINT32_MAX;
 	uint32_t ghost_input_count = 0;
 	uint32_t last_sent_state_input_id = 0;
-	real_t client_tick_additional_speed = 0.0;
-	real_t additional_speed_notif_timer = 0.0;
+	uint32_t additional_fps_notif_timer = 0;
 	std::deque<FrameSnapshot> snapshots;
 	bool streaming_paused = false;
 	bool enabled = true;
 
-	uint32_t input_arrival_time = UINT32_MAX;
+	uint32_t previous_frame_received_timestamp = UINT32_MAX;
 	NetUtility::StatisticalRingBuffer<uint32_t> network_watcher;
+	NetUtility::StatisticalRingBuffer<int> consecutive_input_watcher;
 
 	/// Used to sync the dolls.
 	LocalVector<Peer> peers;
@@ -408,7 +390,7 @@ struct ServerController : public Controller {
 			NetworkedController *p_node,
 			int p_traced_frames);
 
-	void process(real_t p_delta);
+	void process(double p_delta);
 	uint32_t last_known_input() const;
 	virtual uint32_t get_current_input_id() const override;
 
@@ -424,11 +406,13 @@ struct ServerController : public Controller {
 	/// Fetch the next inputs, returns true if the input is new.
 	virtual bool fetch_next_input(real_t p_delta);
 
+	void set_frame_input(const FrameSnapshot &p_frame_snapshot);
+
 	void notify_send_state();
 
 	void doll_sync(real_t p_delta);
 
-	/// This function updates the `tick_additional_speed` so that the `frames_inputs`
+	/// This function updates the `tick_additional_fps` so that the `frames_inputs`
 	/// size is enough to reduce the missing packets to 0.
 	///
 	/// When the internet connection is bad, the packets need more time to arrive.
@@ -439,8 +423,7 @@ struct ServerController : public Controller {
 	/// the server is artificial and no more dependent on the internet. For this
 	/// reason the server tells the client to slowdown so to keep the `frames_inputs`
 	/// size moderate to the needs.
-	virtual void calculates_player_tick_rate(real_t p_delta);
-	virtual void adjust_player_tick_rate(real_t p_delta);
+	virtual void adjust_player_tick_rate(double p_delta);
 
 	uint32_t find_peer(int p_peer) const;
 };
@@ -452,31 +435,32 @@ struct AutonomousServerController : public ServerController {
 	virtual void receive_inputs(const Vector<uint8_t> &p_data) override;
 	virtual int get_inputs_count() const override;
 	virtual bool fetch_next_input(real_t p_delta) override;
-	virtual void calculates_player_tick_rate(real_t p_delta) override;
-	virtual void adjust_player_tick_rate(real_t p_delta) override;
+	virtual void adjust_player_tick_rate(double p_delta) override;
 };
 
 struct PlayerController : public Controller {
 	uint32_t current_input_id;
 	uint32_t input_buffers_counter;
-	real_t time_bank;
-	real_t tick_additional_speed;
+	double time_bank;
+	double acceleration_fps_speed = 0.0;
+	double acceleration_fps_timer = 1.0;
 	bool streaming_paused = false;
+	double pretended_delta = 1.0;
 
 	std::deque<FrameSnapshot> frames_snapshot;
 	LocalVector<uint8_t> cached_packet_data;
 
 	PlayerController(NetworkedController *p_node);
 
-	void process(real_t p_delta);
-	int calculates_sub_ticks(real_t p_delta, real_t p_iteration_per_seconds);
+	void process(double p_delta);
+	/// Returns the amount of frames to process for this frame.
+	int calculates_sub_ticks(const double p_delta, const double p_iteration_per_seconds);
 	int notify_input_checked(uint32_t p_input_id);
 	uint32_t last_known_input() const;
 	uint32_t get_stored_input_id(int p_i) const;
 	virtual uint32_t get_current_input_id() const override;
 
 	bool process_instant(int p_i, real_t p_delta);
-	real_t get_pretended_delta(real_t p_iteration_per_second) const;
 
 	void store_input_buffer(uint32_t p_id);
 
@@ -521,7 +505,7 @@ struct DollController : public Controller {
 	DollController(NetworkedController *p_node);
 
 	virtual void ready() override;
-	void process(real_t p_delta);
+	void process(double p_delta);
 	// TODO consider make this non virtual
 	virtual uint32_t get_current_input_id() const override;
 
@@ -538,7 +522,7 @@ struct NoNetController : public Controller {
 
 	NoNetController(NetworkedController *p_node);
 
-	void process(real_t p_delta);
+	void process(double p_delta);
 	virtual uint32_t get_current_input_id() const override;
 };
 

--- a/scene_synchronizer.cpp
+++ b/scene_synchronizer.cpp
@@ -1860,7 +1860,8 @@ void NoNetSynchronizer::process() {
 		return;
 	}
 
-	const real_t delta = scene_synchronizer->get_physics_process_delta_time();
+	const double physics_ticks_per_second = Engine::get_singleton()->get_iterations_per_second();
+	const double delta = 1.0 / physics_ticks_per_second;
 
 	// Process the scene
 	for (uint32_t i = 0; i < scene_synchronizer->node_data.size(); i += 1) {
@@ -1934,7 +1935,8 @@ void ServerSynchronizer::clear() {
 void ServerSynchronizer::process() {
 	scene_synchronizer->update_peers();
 
-	const real_t delta = scene_synchronizer->get_physics_process_delta_time();
+	const double physics_ticks_per_second = Engine::get_singleton()->get_iterations_per_second();
+	const double delta = 1.0 / physics_ticks_per_second;
 
 	// Process the scene
 	for (uint32_t i = 0; i < scene_synchronizer->node_data.size(); i += 1) {
@@ -2550,8 +2552,8 @@ void ClientSynchronizer::process() {
 		return;
 	}
 
-	const real_t delta = scene_synchronizer->get_physics_process_delta_time();
-	const real_t physics_ticks_per_second = Engine::get_singleton()->get_iterations_per_second();
+	const double physics_ticks_per_second = Engine::get_singleton()->get_iterations_per_second();
+	const double delta = 1.0 / physics_ticks_per_second;
 
 #ifdef DEBUG_ENABLED
 	if (unlikely(Engine::get_singleton()->get_frames_per_second() < physics_ticks_per_second)) {


### PR DESCRIPTION
# All the changes
## The previous algorithm
The server was detecting the amount of packets the client should be ahead: this is known as virtual latency and you will find it as `optimal_frame_delay`.
Then the server was calculating how many packets the client was ahead the server `consecutive_inputs`.
The client was receiving an acceleration factor that was calculated using the delta between those two variables and some other logic.

This mechanism was working ok, but due to the imprecise nature of the acceleration algorithm, the client was unable to always produce the correct number of packets.

## The new algorithm
The  server still fetches `optimal_frame_delay` and `consecutive_inputs`; but this time the delta is right away notified to the client.

Once the client receives the delta, it accelerates exactly that frame count: no more, no less.

## The way how optimal_frame_delay is computed
Another important aspect of this system is that `optimal_frame_delay` is now computed using the exact time in **ms** that each packets takes to be received on the server. So we don't even need to use the old `sensitivity`; by using the exact time the server is much more precise understanding what's the best `optimal_frame_delay`.

## `real_t` to `double`
All the data that should represent the time, are now using `double` instead of `real_t` (`float`).

4.0 version: https://github.com/GodotNetworking/network_synchronizer/pull/54