### PR TITLE
Enhance the NetSync debugger

### DIFF
--- a/scene_synchronizer.cpp
+++ b/scene_synchronizer.cpp
@@ -2747,6 +2747,8 @@ void ClientSynchronizer::receive_snapshot(Variant p_snapshot) {
 	// incremental update so the last received data is always needed to fully
 	// reconstruct it.
 
+	SceneSynchronizerDebugger::singleton()->debug_print(scene_synchronizer, "The Client received the server snapshot.");
+
 	// Parse server snapshot.
 	const bool success = parse_snapshot(p_snapshot);
 
@@ -2999,6 +3001,8 @@ void ClientSynchronizer::store_controllers_snapshot(
 		return;
 	}
 
+	SceneSynchronizerDebugger::singleton()->debug_print(scene_synchronizer, "The Client received the server snapshot: " + itos(p_snapshot.input_id));
+
 	if (r_snapshot_storage.empty() == false) {
 		// Make sure the snapshots are stored in order.
 		const uint32_t last_stored_input_id = r_snapshot_storage.back().input_id;
@@ -3007,7 +3011,12 @@ void ClientSynchronizer::store_controllers_snapshot(
 			r_snapshot_storage.back() = p_snapshot;
 			return;
 		} else {
-			ERR_FAIL_COND_MSG(p_snapshot.input_id < last_stored_input_id, "This snapshot (with ID: " + itos(p_snapshot.input_id) + ") is not expected because the last stored id is: " + itos(last_stored_input_id));
+			if (p_snapshot.input_id < last_stored_input_id) {
+				SceneSynchronizerDebugger::singleton()->debug_error(
+						scene_synchronizer,
+						"This snapshot (with ID: " + itos(p_snapshot.input_id) + ") is dropped because the last stored id is: " + itos(last_stored_input_id),
+						false);
+			}
 		}
 	}
 

--- a/scene_synchronizer_debugger.cpp
+++ b/scene_synchronizer_debugger.cpp
@@ -334,7 +334,7 @@ void SceneSynchronizerDebugger::write_dump(int p_peer, uint32_t p_frame_index) {
 			file_path = main_dump_directory_path + "/" + dump_name + "/fd-" /*+ itos(p_peer) + "-"*/ + itos(p_frame_index) + iteration_mark + ".json";
 			iteration_mark += "@";
 			iteration += 1;
-		} while (FileAccess::exists(file_path) && iteration < 50);
+		} while (FileAccess::exists(file_path) && iteration < 100);
 
 		Error e;
 		file = FileAccess::open(file_path, FileAccess::WRITE, &e);

--- a/scene_synchronizer_debugger.cpp
+++ b/scene_synchronizer_debugger.cpp
@@ -57,9 +57,9 @@ void SceneSynchronizerDebugger::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_node_message", "node", "message"), &SceneSynchronizerDebugger::add_node_message);
 	ClassDB::bind_method(D_METHOD("add_node_message_by_path", "node_path", "message"), &SceneSynchronizerDebugger::add_node_message_by_path);
 
-	ClassDB::bind_method(D_METHOD("debug_print", "node", "message"), &SceneSynchronizerDebugger::debug_print);
-	ClassDB::bind_method(D_METHOD("debug_warning", "node", "message"), &SceneSynchronizerDebugger::debug_warning);
-	ClassDB::bind_method(D_METHOD("debug_error", "node", "message"), &SceneSynchronizerDebugger::debug_error);
+	ClassDB::bind_method(D_METHOD("debug_print", "node", "message", "silent"), &SceneSynchronizerDebugger::debug_print);
+	ClassDB::bind_method(D_METHOD("debug_warning", "node", "message", "silent"), &SceneSynchronizerDebugger::debug_warning);
+	ClassDB::bind_method(D_METHOD("debug_error", "node", "message", "silent"), &SceneSynchronizerDebugger::debug_error);
 }
 
 SceneSynchronizerDebugger::SceneSynchronizerDebugger() :
@@ -324,10 +324,22 @@ void SceneSynchronizerDebugger::write_dump(int p_peer, uint32_t p_frame_index) {
 		return;
 	}
 
-	Error e;
-	FileAccess *file = FileAccess::open(main_dump_directory_path + "/" + dump_name + "/fd-" /*+ itos(p_peer) + "-"*/ + itos(p_frame_index) + ".json", FileAccess::WRITE, &e);
+	FileAccess *file = nullptr;
+	{
+		String file_path = "";
 
-	ERR_FAIL_COND(e != OK);
+		int iteration = 0;
+		String iteration_mark = "";
+		do {
+			file_path = main_dump_directory_path + "/" + dump_name + "/fd-" /*+ itos(p_peer) + "-"*/ + itos(p_frame_index) + iteration_mark + ".json";
+			iteration_mark += "@";
+			iteration += 1;
+		} while (FileAccess::exists(file_path) && iteration < 50);
+
+		Error e;
+		file = FileAccess::open(file_path, FileAccess::WRITE, &e);
+		ERR_FAIL_COND(e != OK);
+	}
 
 	String frame_summary;
 


### PR DESCRIPTION
4.0 version: https://github.com/GodotNetworking/network_synchronizer/pull/68

# Enhances the `NetSync` debugger

- This PR makes the NetSync verbose; now the critical parts of the code leave a trace simplifying the process of debugging using the NetSync-debugger.

- On top of that, the debugger (both UI and backend) was changed to store all the processed frame, regardless the frame ID: Under some specific conditions, the net sync may re-process a frame (for example when the input is missing). In all those cases when the frame is processed again, the net sync doesn't override the frame data, rather it created a new iteration: which is now well visible on the UI.

- This PR, contains a small fix on the `fetch_next` function: the `ghost_input_count += 1;` was moved after the input search loop, avoiding to immediately fetch the following input.