### PR TITLE
Enhances the `NetSync` debugger

### DIFF
--- a/networked_controller.cpp
+++ b/networked_controller.cpp
@@ -705,6 +705,7 @@ void ServerController::process(double p_delta) {
 
 	if (unlikely(current_input_buffer_id == UINT32_MAX)) {
 		// Skip this until the first input arrive.
+		SceneSynchronizerDebugger::singleton()->debug_print(node, "Server skips this frame as the current_input_buffer_id == UINT32_MAX", true);
 		return;
 	}
 
@@ -912,13 +913,17 @@ bool ServerController::fetch_next_input(real_t p_delta) {
 			network_watcher.reset(0);
 			consecutive_input_watcher.reset(0.0);
 			previous_frame_received_timestamp = UINT32_MAX;
+			SceneSynchronizerDebugger::singleton()->debug_print(node, "[ServerController::fetch_next_input] Input `" + itos(current_input_buffer_id) + "` selected as first input.", true);
 		} else {
 			is_new_input = false;
+			SceneSynchronizerDebugger::singleton()->debug_print(node, "[ServerController::fetch_next_input] Still no inputs.", true);
 		}
 	} else {
 		const uint32_t next_input_id = current_input_buffer_id + 1;
+		SceneSynchronizerDebugger::singleton()->debug_print(node, "[ServerController::fetch_next_input] The server is looking for: " + itos(next_input_id), true);
 
 		if (unlikely(streaming_paused)) {
+			SceneSynchronizerDebugger::singleton()->debug_print(node, "[ServerController::fetch_next_input] The streaming is paused.", true);
 			// Stream is paused.
 			if (snapshots.empty() == false &&
 					snapshots.front().id >= next_input_id) {
@@ -939,13 +944,18 @@ bool ServerController::fetch_next_input(real_t p_delta) {
 			}
 		} else if (unlikely(snapshots.empty() == true)) {
 			// The input buffer is empty; a packet is missing.
+			SceneSynchronizerDebugger::singleton()->debug_print(node, "[ServerController::fetch_next_input] Missing input: " + itos(next_input_id) + " Input buffer is void, i'm using the previous one!");
+
 			is_new_input = false;
 			ghost_input_count += 1;
-			SceneSynchronizerDebugger::singleton()->debug_print(node, "Missing input: " + itos(next_input_id) + " Input buffer is void, i'm using the previous one!");
 
 		} else {
+			SceneSynchronizerDebugger::singleton()->debug_print(node, "[ServerController::fetch_next_input] The input buffer is not empty, so looking for the next input. Hopefully `" + itos(next_input_id) + "`", true);
+
 			// The input buffer is not empty, search the new input.
 			if (next_input_id == snapshots.front().id) {
+				SceneSynchronizerDebugger::singleton()->debug_print(node, "[ServerController::fetch_next_input] The input `" + itos(next_input_id) + "` was found.", true);
+
 				// Wow, the next input is perfect!
 				set_frame_input(snapshots.front());
 				snapshots.pop_front();
@@ -987,7 +997,8 @@ bool ServerController::fetch_next_input(real_t p_delta) {
 				// For this reason we keep track the amount of missing packets
 				// using `ghost_input_count`.
 
-				ghost_input_count += 1;
+				SceneSynchronizerDebugger::singleton()->debug_print(node, "[ServerController::fetch_next_input] The input `" + itos(next_input_id) + "` was NOT found. Recovering process started.", true);
+				SceneSynchronizerDebugger::singleton()->debug_print(node, "[ServerController::fetch_next_input] ghost_input_count: `" + itos(ghost_input_count) + "`", true);
 
 				const int size = MIN(ghost_input_count, snapshots.size());
 				const uint32_t ghost_packet_id = next_input_id + ghost_input_count;
@@ -998,9 +1009,15 @@ bool ServerController::fetch_next_input(real_t p_delta) {
 				DataBuffer pir_A = node->get_inputs_buffer();
 
 				for (int i = 0; i < size; i += 1) {
+					SceneSynchronizerDebugger::singleton()->debug_print(node, "[ServerController::fetch_next_input] checking if `" + itos(snapshots.front().id) + "` can be used to recover `" + itos(next_input_id) + "`.", true);
+
 					if (ghost_packet_id < snapshots.front().id) {
+						SceneSynchronizerDebugger::singleton()->debug_print(node, "[ServerController::fetch_next_input] The input `" + itos(snapshots.front().id) + "` can't be used as the ghost_packet_id (`" + itos(ghost_packet_id) + "`) is more than the input.", true);
 						break;
 					} else {
+						const uint32_t input_id = snapshots.front().id;
+						SceneSynchronizerDebugger::singleton()->debug_print(node, "[ServerController::fetch_next_input] The input `" + itos(input_id) + "` is eligible as next frame.", true);
+
 						pi = snapshots.front();
 						snapshots.pop_front();
 						recovered = true;
@@ -1021,6 +1038,7 @@ bool ServerController::fetch_next_input(real_t p_delta) {
 
 						const bool are_different = node->native_are_inputs_different(pir_A, pir_B);
 						if (are_different) {
+							SceneSynchronizerDebugger::singleton()->debug_print(node, "[ServerController::fetch_next_input] The input `" + itos(input_id) + "` is different from the one executed so far, so better to execute it.", true);
 							break;
 						}
 					}
@@ -1029,10 +1047,11 @@ bool ServerController::fetch_next_input(real_t p_delta) {
 				if (recovered) {
 					set_frame_input(pi);
 					ghost_input_count = 0;
-					SceneSynchronizerDebugger::singleton()->debug_print(node, "Packet recovered");
+					SceneSynchronizerDebugger::singleton()->debug_print(node, "Packet recovered. The new InputID is: `" + itos(current_input_buffer_id) + "`");
 				} else {
+					ghost_input_count += 1;
 					is_new_input = false;
-					SceneSynchronizerDebugger::singleton()->debug_print(node, "Packet still missing");
+					SceneSynchronizerDebugger::singleton()->debug_print(node, "Packet still missing, the server is still using the old input.");
 				}
 			}
 		}

--- a/scene_synchronizer.cpp
+++ b/scene_synchronizer.cpp
@@ -2754,6 +2754,8 @@ void ClientSynchronizer::receive_snapshot(Variant p_snapshot) {
 	// incremental update so the last received data is always needed to fully
 	// reconstruct it.
 
+	SceneSynchronizerDebugger::singleton()->debug_print(scene_synchronizer, "The Client received the server snapshot.");
+
 	// Parse server snapshot.
 	const bool success = parse_snapshot(p_snapshot);
 
@@ -3006,6 +3008,8 @@ void ClientSynchronizer::store_controllers_snapshot(
 		return;
 	}
 
+	SceneSynchronizerDebugger::singleton()->debug_print(scene_synchronizer, "The Client received the server snapshot: " + itos(p_snapshot.input_id));
+
 	if (r_snapshot_storage.empty() == false) {
 		// Make sure the snapshots are stored in order.
 		const uint32_t last_stored_input_id = r_snapshot_storage.back().input_id;
@@ -3014,7 +3018,12 @@ void ClientSynchronizer::store_controllers_snapshot(
 			r_snapshot_storage.back() = p_snapshot;
 			return;
 		} else {
-			ERR_FAIL_COND_MSG(p_snapshot.input_id < last_stored_input_id, "This snapshot (with ID: " + itos(p_snapshot.input_id) + ") is not expected because the last stored id is: " + itos(last_stored_input_id));
+			if (p_snapshot.input_id < last_stored_input_id) {
+				SceneSynchronizerDebugger::singleton()->debug_error(
+						scene_synchronizer,
+						"This snapshot (with ID: " + itos(p_snapshot.input_id) + ") is dropped because the last stored id is: " + itos(last_stored_input_id),
+						false);
+			}
 		}
 	}
 

--- a/scene_synchronizer_debugger.cpp
+++ b/scene_synchronizer_debugger.cpp
@@ -319,7 +319,7 @@ void SceneSynchronizerDebugger::write_dump(int p_peer, uint32_t p_frame_index) {
 			file_path = main_dump_directory_path + "/" + dump_name + "/fd-" /*+ itos(p_peer) + "-"*/ + itos(p_frame_index) + iteration_mark + ".json";
 			iteration_mark += "@";
 			iteration += 1;
-		} while (FileAccess::exists(file_path) && iteration < 50);
+		} while (FileAccess::exists(file_path) && iteration < 100);
 
 		Error e;
 		file = FileAccess::open(file_path, FileAccess::WRITE, &e);

--- a/scene_synchronizer_debugger.cpp
+++ b/scene_synchronizer_debugger.cpp
@@ -33,15 +33,15 @@
 #ifdef DEBUG_ENABLED
 
 #include "__generated__debugger_ui.h"
-#include "core/io/json.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
+#include "core/io/json.h"
 #include "core/os/os.h"
 #include "data_buffer.h"
 #include "net_utilities.h"
 #include "scene/main/viewport.h"
-#include "scene_synchronizer.h"
 #include "scene/main/window.h"
+#include "scene_synchronizer.h"
 
 #endif
 
@@ -58,9 +58,9 @@ void SceneSynchronizerDebugger::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_node_message", "node", "message"), &SceneSynchronizerDebugger::add_node_message);
 	ClassDB::bind_method(D_METHOD("add_node_message_by_path", "node_path", "message"), &SceneSynchronizerDebugger::add_node_message_by_path);
 
-	ClassDB::bind_method(D_METHOD("debug_print", "node", "message"), &SceneSynchronizerDebugger::debug_print);
-	ClassDB::bind_method(D_METHOD("debug_warning", "node", "message"), &SceneSynchronizerDebugger::debug_warning);
-	ClassDB::bind_method(D_METHOD("debug_error", "node", "message"), &SceneSynchronizerDebugger::debug_error);
+	ClassDB::bind_method(D_METHOD("debug_print", "node", "message", "silent"), &SceneSynchronizerDebugger::debug_print);
+	ClassDB::bind_method(D_METHOD("debug_warning", "node", "message", "silent"), &SceneSynchronizerDebugger::debug_warning);
+	ClassDB::bind_method(D_METHOD("debug_error", "node", "message", "silent"), &SceneSynchronizerDebugger::debug_error);
 }
 
 SceneSynchronizerDebugger::SceneSynchronizerDebugger() :
@@ -309,10 +309,22 @@ void SceneSynchronizerDebugger::write_dump(int p_peer, uint32_t p_frame_index) {
 		return;
 	}
 
-	Error e;
-	Ref<FileAccess> file = FileAccess::open(main_dump_directory_path + "/" + dump_name + "/fd-" /*+ itos(p_peer) + "-"*/ + itos(p_frame_index) + ".json", FileAccess::WRITE, &e);
+	FileAccess *file = nullptr;
+	{
+		String file_path = "";
 
-	ERR_FAIL_COND(e != OK);
+		int iteration = 0;
+		String iteration_mark = "";
+		do {
+			file_path = main_dump_directory_path + "/" + dump_name + "/fd-" /*+ itos(p_peer) + "-"*/ + itos(p_frame_index) + iteration_mark + ".json";
+			iteration_mark += "@";
+			iteration += 1;
+		} while (FileAccess::exists(file_path) && iteration < 50);
+
+		Error e;
+		file = FileAccess::open(file_path, FileAccess::WRITE, &e);
+		ERR_FAIL_COND(e != OK);
+	}
 
 	String frame_summary;
 


### PR DESCRIPTION
Port of: https://github.com/GodotNetworking/network_synchronizer/pull/67

# Enhances the `NetSync` debugger

- This PR makes the NetSync verbose; now the critical parts of the code leave a trace simplifying the process of debugging using the NetSync-debugger.

- On top of that, the debugger (both UI and backend) was changed to store all the processed frame, regardless the frame ID: Under some specific conditions, the net sync may re-process a frame (for example when the input is missing). In all those cases when the frame is processed again, the net sync doesn't override the frame data, rather it created a new iteration: which is now well visible on the UI.

- This PR, contains a small fix on the `fetch_next` function: the `ghost_input_count += 1;` was moved after the input search loop, avoiding to immediately fetch the following input.