### PR TITLE
Enable scene synchronization without an client Controller.

### DIFF
--- a/scene_synchronizer.cpp
+++ b/scene_synchronizer.cpp
@@ -3824,7 +3824,7 @@ bool ClientSynchronizer::parse_snapshot(Variant p_snapshot) {
 	if (unlikely(received_snapshot.input_id == UINT32_MAX && player_controller_node_data != nullptr)) {
 		// We espect that the player_controller is updated by this new snapshot,
 		// so make sure it's done so.
-		SceneSynchronizerDebugger::singleton()->debug_print(scene_synchronizer, "[INFO] the player controller (" + player_controller_node_data->node->get_path() + ") was not part of the received snapshot, this happens when the server destroy the peer controller. NetUtility::Snapshot:");
+		SceneSynchronizerDebugger::singleton()->debug_print(scene_synchronizer, "[INFO] the player controller (" + player_controller_node_data->node->get_path() + ") was not part of the received snapshot, this happens when the server destroys the peer controller. NetUtility::Snapshot:");
 		SceneSynchronizerDebugger::singleton()->debug_print(scene_synchronizer, p_snapshot);
 	}
 

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -476,7 +476,7 @@ public:
 	void process_snapshot_notificator(real_t p_delta);
 	Vector<Variant> global_nodes_generate_snapshot(bool p_force_full_snapshot) const;
 	void controller_generate_snapshot(const NetUtility::NodeData *p_node_data, bool p_force_full_snapshot, Vector<Variant> &r_snapshot_result) const;
-	void generate_snapshot_node_data(const NetUtility::NodeData *p_node_data, SnapshotGenerationMode p_mode, bool p_include_controller_input_id, Vector<Variant> &r_result) const;
+	void generate_snapshot_node_data(const NetUtility::NodeData *p_node_data, SnapshotGenerationMode p_mode, Vector<Variant> &r_result) const;
 
 	void execute_actions();
 	void send_actions_to_clients();
@@ -545,7 +545,8 @@ public:
 			Variant p_snapshot,
 			void *p_user_pointer,
 			void (*p_node_parse)(void *p_user_pointer, NetUtility::NodeData *p_node_data),
-			void (*p_controller_parse)(void *p_user_pointer, NetUtility::NodeData *p_node_data, uint32_t p_input_id),
+			void (*p_input_id_parse)(void *p_user_pointer, uint32_t p_input_id),
+			void (*p_controller_parse)(void *p_user_pointer, NetUtility::NodeData *p_node_data),
 			void (*p_variable_parse)(void *p_user_pointer, NetUtility::NodeData *p_node_data, NetVarId p_var_id, const Variant &p_value));
 
 	void set_enabled(bool p_enabled);
@@ -559,6 +560,7 @@ private:
 			std::deque<NetUtility::Snapshot> &r_snapshot_storage);
 
 	void process_controllers_recovery(real_t p_delta);
+	void apply_last_received_server_snapshot();
 	void process_paused_controller_recovery(real_t p_delta);
 	bool parse_snapshot(Variant p_snapshot);
 	bool compare_vars(


### PR DESCRIPTION
This commit allows to client to receive the server snapshot sync even when the local controller doesn't exist.

The InputID generated by the controller is now optinal, when the Controller doesn't exist; in such case the server snapshot is immediately applied while the rewinding mechanism is entirely disabled.

It was necessary to modify the snapshot format: now the `InputID` is stored separately from the controller `NodeData` and moved at the top of the array.

Receiving a corrupted snapshot data was fatal for the client, as the corrupted data were leaking into the buffer, leaving the client unable to function properly. This commit fix that by making sure a separate buffer is used during the snapshot parsing.

The snapshot parsing algorithm was initializing the variables ONLY if a variable was specified on the received snapshot. This was causing a crash if the snapshot contained an empty NodeData buffer. This got fixed by making sure the variables are initialized on the snapshot NodeData parsing.