### PR TITLE
Ct/doll ref

### DIFF
--- a/bit_array.cpp
+++ b/bit_array.cpp
@@ -45,18 +45,18 @@ BitArray::BitArray(const Vector<uint8_t> &p_bytes) :
 		bytes(p_bytes) {
 }
 
-void BitArray::resize_in_bytes(int p_bytes) {
-	ERR_FAIL_COND_MSG(p_bytes < 0, "Bytes count can't be negative");
-	bytes.resize(p_bytes);
+void BitArray::resize_in_bytes(int p_bytes_count) {
+	ERR_FAIL_COND_MSG(p_bytes_count < 0, "Bytes count can't be negative");
+	bytes.resize(p_bytes_count);
 }
 
 int BitArray::size_in_bytes() const {
 	return bytes.size();
 }
 
-void BitArray::resize_in_bits(int p_bits) {
-	ERR_FAIL_COND_MSG(p_bits < 0, "Bits count can't be negative");
-	const int min_size = Math::ceil((static_cast<float>(p_bits)) / 8);
+void BitArray::resize_in_bits(int p_bits_count) {
+	ERR_FAIL_COND_MSG(p_bits_count < 0, "Bits count can't be negative");
+	const int min_size = Math::ceil((static_cast<float>(p_bits_count)) / 8);
 	bytes.resize(min_size);
 }
 

--- a/bit_array.h
+++ b/bit_array.h
@@ -53,10 +53,10 @@ public:
 		return bytes;
 	}
 
-	void resize_in_bytes(int p_bits);
+	void resize_in_bytes(int p_bytes_count);
 	int size_in_bytes() const;
 
-	void resize_in_bits(int p_bits);
+	void resize_in_bits(int p_bits_count);
 	int size_in_bits() const;
 
 	void store_bits(int p_bit_offset, uint64_t p_value, int p_bits);

--- a/data_buffer.cpp
+++ b/data_buffer.cpp
@@ -643,7 +643,6 @@ Vector2 DataBuffer::read_normalized_vector2(CompressionLevel p_compression_level
 }
 
 Vector3 DataBuffer::add_vector3(Vector3 p_input, CompressionLevel p_compression_level) {
-	print_line("DB ptr: " + itos((uint64_t)this)); // TODO remove.
 	ERR_FAIL_COND_V(is_reading == true, p_input);
 
 #ifndef REAL_T_IS_DOUBLE

--- a/data_buffer.h
+++ b/data_buffer.h
@@ -75,6 +75,13 @@ public:
 	/// COMPRESSION_LEVEL_3: 8 bits are used - Stores integers -128 / 127
 	///
 	///
+	/// ## Uint
+	/// COMPRESSION_LEVEL_0: 64 bits are used - Stores integers 18446744073709551615
+	/// COMPRESSION_LEVEL_1: 32 bits are used - Stores integers 4294967295
+	/// COMPRESSION_LEVEL_2: 16 bits are used - Stores integers 65535
+	/// COMPRESSION_LEVEL_3: 8 bits are used - Stores integers 2SS
+	///
+	///
 	/// ## Real
 	/// Precision depends on an integer range
 	/// COMPRESSION_LEVEL_0: 64 bits are used - Double precision. Up to 16 precision is 0.00000000000000177636 in worst case. Up to 512 precision is 0.00000000000005684342 in worst case. Up to 1024 precision is 0.00000000000011368684 in worst case.

--- a/data_buffer.h
+++ b/data_buffer.h
@@ -54,6 +54,7 @@ public:
 		DATA_TYPE_NORMALIZED_VECTOR2,
 		DATA_TYPE_VECTOR3,
 		DATA_TYPE_NORMALIZED_VECTOR3,
+		DATA_TYPE_BITS,
 		// The only dynamic sized value.
 		DATA_TYPE_VARIANT
 	};
@@ -306,6 +307,10 @@ public:
 
 	/// Parse the next data as Variant and returns it.
 	Variant read_variant();
+
+	/// Add bits
+	void add_bits(const Vector<uint8_t> &p_data, int p_bit_count);
+	Vector<uint8_t> read_bits(int p_bit_count);
 
 	/// Puts all the bytes to 0.
 	void zero();

--- a/input_network_encoder.cpp
+++ b/input_network_encoder.cpp
@@ -49,6 +49,9 @@ uint32_t InputNetworkEncoder::register_input(
 		case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR3:
 			ERR_FAIL_COND_V_MSG(p_default_value.get_type() != Variant::VECTOR3, UINT32_MAX, "The moveset initialization failed for" + p_name + " the specified data type is `Vector3` but the default parameter is " + itos(p_default_value.get_type()));
 			break;
+		case DataBuffer::DATA_TYPE_BITS:
+			CRASH_NOW_MSG("NOT SUPPORTED.");
+			break;
 		case DataBuffer::DATA_TYPE_VARIANT:
 			/* No need to check variant, anything is accepted at this point.*/
 			break;
@@ -133,6 +136,9 @@ void InputNetworkEncoder::encode(const LocalVector<Variant> &p_input, DataBuffer
 					case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR3:
 						_ALLOW_DISCARD_ r_buffer.add_normalized_vector3(pending_input.operator Vector3(), info.compression_level);
 						break;
+					case DataBuffer::DATA_TYPE_BITS:
+						CRASH_NOW_MSG("Not supported.");
+						break;
 					case DataBuffer::DATA_TYPE_VARIANT:
 						_ALLOW_DISCARD_ r_buffer.add_variant(pending_input);
 						break;
@@ -198,6 +204,9 @@ void InputNetworkEncoder::decode(DataBuffer &p_buffer, LocalVector<Variant> &r_i
 				case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR3:
 					r_inputs[i] = p_buffer.read_normalized_vector3(info.compression_level);
 					break;
+				case DataBuffer::DATA_TYPE_BITS:
+					CRASH_NOW_MSG("Not supported.");
+					break;
 				case DataBuffer::DATA_TYPE_VARIANT:
 					r_inputs[i] = p_buffer.read_variant();
 					break;
@@ -262,6 +271,9 @@ bool InputNetworkEncoder::are_different(DataBuffer &p_buffer_A, DataBuffer &p_bu
 				case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR3:
 					are_equals = SceneSynchronizer::compare(p_buffer_A.read_normalized_vector3(info.compression_level), p_buffer_B.read_normalized_vector3(info.compression_level), info.comparison_floating_point_precision);
 					break;
+				case DataBuffer::DATA_TYPE_BITS:
+					CRASH_NOW_MSG("Not supported.");
+					break;
 				case DataBuffer::DATA_TYPE_VARIANT:
 					are_equals = SceneSynchronizer::compare(p_buffer_A.read_variant(), p_buffer_B.read_variant(), info.comparison_floating_point_precision);
 					break;
@@ -323,6 +335,9 @@ uint32_t InputNetworkEncoder::count_size(DataBuffer &p_buffer) const {
 						break;
 					case DataBuffer::DATA_TYPE_NORMALIZED_VECTOR3:
 						size += p_buffer.read_normalized_vector3_size(info.compression_level);
+						break;
+					case DataBuffer::DATA_TYPE_BITS:
+						CRASH_NOW_MSG("Not supported.");
 						break;
 					case DataBuffer::DATA_TYPE_VARIANT:
 						size += p_buffer.read_variant_size();

--- a/net_utilities.cpp
+++ b/net_utilities.cpp
@@ -36,6 +36,8 @@
 
 #include "scene/main/node.h"
 
+const uint32_t NetID_NONE = UINT32_MAX;
+
 bool NetUtility::ChangeListener::operator==(const ChangeListener &p_other) const {
 	return object_id == p_other.object_id && method == p_other.method;
 }

--- a/net_utilities.cpp
+++ b/net_utilities.cpp
@@ -95,6 +95,23 @@ bool NetUtility::NodeChangeListener::operator==(const NodeChangeListener &p_othe
 	return node_data == p_other.node_data && var_id == p_other.var_id;
 }
 
+bool NetUtility::RealtimeSyncGroup::is_node_list_changed() const {
+	return nodes_list_changed;
+}
+
+const LocalVector<NetUtility::NodeData *> &NetUtility::RealtimeSyncGroup::get_nodes() const {
+	return nodes;
+}
+
+const LocalVector<NetUtility::RealtimeSyncGroup::Change> &NetUtility::RealtimeSyncGroup::get_changes() const {
+	return changes;
+}
+
+void NetUtility::RealtimeSyncGroup::mark_changes_as_notified() {
+	changes.clear();
+	nodes_list_changed = false;
+}
+
 void NetUtility::RealtimeSyncGroup::add_new_node(NodeData *p_node_data) {
 	if (nodes.find(p_node_data) == -1) {
 		if (changes.size() <= p_node_data->id) {
@@ -104,6 +121,7 @@ void NetUtility::RealtimeSyncGroup::add_new_node(NodeData *p_node_data) {
 		changes[p_node_data->id].not_known_before = true;
 
 		nodes.push_back(p_node_data);
+		nodes_list_changed = true;
 
 		for (int i = 0; i < int(p_node_data->vars.size()); ++i) {
 			notify_new_variable(p_node_data, p_node_data->vars[i].var.name);
@@ -113,6 +131,7 @@ void NetUtility::RealtimeSyncGroup::add_new_node(NodeData *p_node_data) {
 
 void NetUtility::RealtimeSyncGroup::remove_node(NodeData *p_node_data) {
 	nodes.erase(p_node_data);
+	nodes_list_changed = true;
 }
 
 void NetUtility::RealtimeSyncGroup::notify_new_variable(NodeData *p_node_data, const StringName &p_var_name) {

--- a/net_utilities.cpp
+++ b/net_utilities.cpp
@@ -69,6 +69,10 @@ bool NetUtility::NodeData::has_registered_process_functions() const {
 	return false;
 }
 
+bool NetUtility::NodeData::can_deferred_sync() const {
+	return collect_epoch_func.is_valid() && apply_epoch_func.is_valid();
+}
+
 NetUtility::Snapshot::operator String() const {
 	String s;
 	s += "Snapshot input ID: " + itos(input_id);

--- a/net_utilities.cpp
+++ b/net_utilities.cpp
@@ -94,3 +94,40 @@ NetUtility::Snapshot::operator String() const {
 bool NetUtility::NodeChangeListener::operator==(const NodeChangeListener &p_other) const {
 	return node_data == p_other.node_data && var_id == p_other.var_id;
 }
+
+void NetUtility::RealtimeSyncGroup::add_new_node(NodeData *p_node_data) {
+	if (nodes.find(p_node_data) == -1) {
+		if (changes.size() <= p_node_data->id) {
+			changes.resize(p_node_data->id + 1);
+		}
+
+		changes[p_node_data->id].not_known_before = true;
+
+		nodes.push_back(p_node_data);
+
+		for (int i = 0; i < int(p_node_data->vars.size()); ++i) {
+			notify_new_variable(p_node_data, p_node_data->vars[i].var.name);
+		}
+	}
+}
+
+void NetUtility::RealtimeSyncGroup::remove_node(NodeData *p_node_data) {
+	nodes.erase(p_node_data);
+}
+
+void NetUtility::RealtimeSyncGroup::notify_new_variable(NodeData *p_node_data, const StringName &p_var_name) {
+	if (changes.size() <= p_node_data->id) {
+		changes.resize(p_node_data->id + 1);
+	}
+
+	changes[p_node_data->id].vars.insert(p_var_name);
+	changes[p_node_data->id].uknown_vars.insert(p_var_name);
+}
+
+void NetUtility::RealtimeSyncGroup::notify_variable_changed(NodeData *p_node_data, const StringName &p_var_name) {
+	if (changes.size() <= p_node_data->id) {
+		changes.resize(p_node_data->id + 1);
+	}
+
+	changes[p_node_data->id].vars.insert(p_var_name);
+}

--- a/net_utilities.h
+++ b/net_utilities.h
@@ -358,19 +358,7 @@ struct NodeData {
 	uint32_t id = 0;
 	ObjectID instance_id = ObjectID();
 
-	// TODO remove this
-	// TODO remove this
-	// TODO remove this
-	// TODO remove this
-	// TODO remove this
-	// TODO remove this
-	// TODO remove this
-	// TODO remove this
-	// TODO remove this
-	// TODO remove this
-	// TODO remove this
-	// TODO remove this
-	bool sync_enabled = true;
+	bool realtime_sync_enabled_on_client = false;
 
 	bool is_controller = false;
 
@@ -424,15 +412,26 @@ public:
 		RBSet<StringName> vars;
 	};
 
-public:
+private:
+	bool nodes_list_changed = false;
 	LocalVector<NetUtility::NodeData *> nodes;
-	LocalVector<int> peers;
 
 	/// The delta changes detected. Used to generate incremental snapshots.
 	/// NOTE: the order matters because the index is the NetNodeId.
 	LocalVector<Change> changes;
 
+public:
+	LocalVector<int> peers;
+
 	real_t state_notifier_timer = 0.0;
+
+public:
+	bool is_node_list_changed() const;
+
+	const LocalVector<NetUtility::NodeData *> &get_nodes() const;
+
+	const LocalVector<Change> &get_changes() const;
+	void mark_changes_as_notified();
 
 	void add_new_node(NodeData *p_node_data);
 	void remove_node(NodeData *p_node_data);

--- a/net_utilities.h
+++ b/net_utilities.h
@@ -135,6 +135,10 @@ static const String ProcessPhaseName[PROCESSPHASE_COUNT] = {
 };
 
 namespace NetUtility {
+// This was needed to optimize the godot stringify for byte arrays.. it was slowing down perfs.
+String stringify_byte_array_fast(const Vector<uint8_t> &p_array);
+String stringify_fast(const Variant &p_var);
+
 template <class T>
 class StatisticalRingBuffer {
 	LocalVector<T> data;
@@ -410,7 +414,7 @@ struct NoRewindRecover {
 struct SyncGroup {
 public:
 	struct Change {
-		bool not_known_before = false;
+		bool unknown = false;
 		RBSet<StringName> uknown_vars;
 		RBSet<StringName> vars;
 	};
@@ -427,6 +431,7 @@ public:
 
 	struct DeferredNodeInfo {
 		NetUtility::NodeData *nd = nullptr;
+		bool unknown = false;
 		float update_rate = 0.5;
 		float update_priority = 0.0;
 
@@ -440,6 +445,7 @@ private:
 	bool realtime_sync_nodes_list_changed = false;
 	LocalVector<RealtimeNodeInfo> realtime_sync_nodes;
 
+	bool deferred_sync_nodes_list_changed = false;
 	LocalVector<DeferredNodeInfo> deferred_sync_nodes;
 
 public:
@@ -448,7 +454,8 @@ public:
 	real_t state_notifier_timer = 0.0;
 
 public:
-	bool is_node_list_changed() const;
+	bool is_realtime_node_list_changed() const;
+	bool is_deferred_node_list_changed() const;
 
 	const LocalVector<NetUtility::SyncGroup::RealtimeNodeInfo> &get_realtime_sync_nodes() const;
 	const LocalVector<NetUtility::SyncGroup::DeferredNodeInfo> &get_deferred_sync_nodes() const;

--- a/net_utilities.h
+++ b/net_utilities.h
@@ -367,7 +367,10 @@ struct NodeData {
 	LocalVector<VarData> vars;
 	LocalVector<Callable> functions[PROCESSPHASE_COUNT];
 
+	// func _collect_epoch_data(buffer: DataBuffer):
 	Callable collect_epoch_func;
+
+	// func _apply_epoch(delta: float, interpolation_alpha: float, past_buffer: DataBuffer, future_buffer: DataBuffer):
 	Callable apply_epoch_func;
 
 	// This is valid to use only inside the process function.
@@ -424,6 +427,8 @@ public:
 
 	struct DeferredNodeInfo {
 		NetUtility::NodeData *nd = nullptr;
+		float update_rate = 0.5;
+		float update_priority = 0.0;
 
 		DeferredNodeInfo() = default;
 		DeferredNodeInfo(NetUtility::NodeData *p_nd) :
@@ -447,6 +452,7 @@ public:
 
 	const LocalVector<NetUtility::SyncGroup::RealtimeNodeInfo> &get_realtime_sync_nodes() const;
 	const LocalVector<NetUtility::SyncGroup::DeferredNodeInfo> &get_deferred_sync_nodes() const;
+	LocalVector<NetUtility::SyncGroup::DeferredNodeInfo> &get_deferred_sync_nodes();
 
 	void mark_changes_as_notified();
 
@@ -455,6 +461,10 @@ public:
 
 	void notify_new_variable(NodeData *p_node_data, const StringName &p_var_name);
 	void notify_variable_changed(NodeData *p_node_data, const StringName &p_var_name);
+
+	void set_deferred_update_rate(NetUtility::NodeData *p_node_data, real_t p_update_rate);
+	real_t get_deferred_update_rate(const NetUtility::NodeData *p_node_data) const;
+	void sort_deferred_node_by_update_priority();
 };
 
 } // namespace NetUtility

--- a/net_utilities.h
+++ b/net_utilities.h
@@ -433,6 +433,12 @@ public:
 	LocalVector<Change> changes;
 
 	real_t state_notifier_timer = 0.0;
+
+	void add_new_node(NodeData *p_node_data);
+	void remove_node(NodeData *p_node_data);
+
+	void notify_new_variable(NodeData *p_node_data, const StringName &p_var_name);
+	void notify_variable_changed(NodeData *p_node_data, const StringName &p_var_name);
 };
 
 } // namespace NetUtility

--- a/net_utilities.h
+++ b/net_utilities.h
@@ -394,6 +394,8 @@ struct PeerData {
 	bool need_full_snapshot = true;
 	// Used to know if the peer is enabled.
 	bool enabled = true;
+	// The Sync group this peer is in.
+	SyncGroupId sync_group_id;
 };
 
 struct Snapshot {

--- a/net_utilities.h
+++ b/net_utilities.h
@@ -57,8 +57,10 @@ class Node;
 #define NET_DEBUG_ERR(msg)
 #endif
 
+extern const uint32_t NetID_NONE;
 typedef uint32_t NetNodeId;
 typedef uint32_t NetVarId;
+typedef uint32_t RealtimeSyncGroupId;
 
 #ifdef TRACY_ENABLE
 
@@ -412,6 +414,11 @@ struct Snapshot {
 struct NoRewindRecover {
 	NodeData *node_data = nullptr;
 	Vector<Var> vars;
+};
+
+struct RealtimeSyncGroup {
+	LocalVector<NetUtility::NodeData *> nodes;
+	LocalVector<int> peers;
 };
 
 } // namespace NetUtility

--- a/net_utilities.h
+++ b/net_utilities.h
@@ -417,8 +417,22 @@ struct NoRewindRecover {
 };
 
 struct RealtimeSyncGroup {
+public:
+	struct Change {
+		bool not_known_before = false;
+		RBSet<StringName> uknown_vars;
+		RBSet<StringName> vars;
+	};
+
+public:
 	LocalVector<NetUtility::NodeData *> nodes;
 	LocalVector<int> peers;
+
+	/// The delta changes detected. Used to generate incremental snapshots.
+	/// NOTE: the order matters because the index is the NetNodeId.
+	LocalVector<Change> changes;
+
+	real_t state_notifier_timer = 0.0;
 };
 
 } // namespace NetUtility

--- a/net_utilities.h
+++ b/net_utilities.h
@@ -356,8 +356,18 @@ struct NodeData {
 	uint32_t id = 0;
 	ObjectID instance_id = ObjectID();
 
-	/// When `false`, this node is not sync. It's usefult to locally pause sync
-	/// of specific nodes.
+	// TODO remove this
+	// TODO remove this
+	// TODO remove this
+	// TODO remove this
+	// TODO remove this
+	// TODO remove this
+	// TODO remove this
+	// TODO remove this
+	// TODO remove this
+	// TODO remove this
+	// TODO remove this
+	// TODO remove this
 	bool sync_enabled = true;
 
 	bool is_controller = false;
@@ -367,12 +377,16 @@ struct NodeData {
 	LocalVector<VarData> vars;
 	LocalVector<Callable> functions[PROCESSPHASE_COUNT];
 
+	Callable collect_epoch_func;
+	Callable apply_epoch_func;
+
 	// This is valid to use only inside the process function.
 	Node *node = nullptr;
 
 	NodeData() = default;
 
 	bool has_registered_process_functions() const;
+	bool can_deferred_sync() const;
 };
 
 struct PeerData {

--- a/networked_controller.cpp
+++ b/networked_controller.cpp
@@ -1564,7 +1564,6 @@ DollController::DollController(NetworkedController *p_node) :
 }
 
 bool DollController::receive_inputs(const Vector<uint8_t> &p_data) {
-	print_line("~~ RECEIVE ~~");
 	const uint32_t now = OS::get_singleton()->get_ticks_msec();
 	struct SCParseTmpData {
 		DollController *controller;
@@ -1683,11 +1682,6 @@ void DollController::process(double p_delta) {
 	String s;
 	for (size_t i = 0; i < snapshots.size(); ++i) {
 		s += itos(snapshots[i].id) + ", ";
-	}
-	if (queued_instant_to_process == -1) {
-		print_line("STANDARD VirtualCI:" + itos(virtual_current_input) + " CI: " + itos(get_current_input_id()) + " --> " + s);
-	} else {
-		print_line("REWIND VirtualCI:" + itos(virtual_current_input) + " CI: " + itos(get_current_input_id()) + " --> " + s);
 	}
 
 	if (current_input_buffer_id > virtual_current_input && current_input_buffer_id != UINT32_MAX) {

--- a/networked_controller.cpp
+++ b/networked_controller.cpp
@@ -43,7 +43,6 @@
 #include <algorithm>
 
 #define METADATA_SIZE 1
-#define DOLL_EPOCH_METADATA_SIZE (DataBuffer::get_bit_taken(DataBuffer::DATA_TYPE_REAL, DataBuffer::COMPRESSION_LEVEL_1) + DataBuffer::get_bit_taken(DataBuffer::DATA_TYPE_INT, DataBuffer::COMPRESSION_LEVEL_1))
 
 void NetworkedController::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_server_controlled", "server_controlled"), &NetworkedController::set_server_controlled);
@@ -70,46 +69,18 @@ void NetworkedController::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_tick_acceleration", "acceleration"), &NetworkedController::set_tick_acceleration);
 	ClassDB::bind_method(D_METHOD("get_tick_acceleration"), &NetworkedController::get_tick_acceleration);
 
-	ClassDB::bind_method(D_METHOD("set_doll_sync_rate", "rate"), &NetworkedController::set_doll_sync_rate);
-	ClassDB::bind_method(D_METHOD("get_doll_sync_rate"), &NetworkedController::get_doll_sync_rate);
-
-	ClassDB::bind_method(D_METHOD("set_doll_min_frames_delay", "delay"), &NetworkedController::set_doll_min_frames_delay);
-	ClassDB::bind_method(D_METHOD("get_doll_min_frames_delay"), &NetworkedController::get_doll_min_frames_delay);
-
-	ClassDB::bind_method(D_METHOD("set_doll_max_frames_delay", "delay"), &NetworkedController::set_doll_max_frames_delay);
-	ClassDB::bind_method(D_METHOD("get_doll_max_frames_delay"), &NetworkedController::get_doll_max_frames_delay);
-
-	ClassDB::bind_method(D_METHOD("set_doll_net_sensitivity", "sensitivity"), &NetworkedController::set_doll_net_sensitivity);
-	ClassDB::bind_method(D_METHOD("get_doll_net_sensitivity"), &NetworkedController::get_doll_net_sensitivity);
-
-	ClassDB::bind_method(D_METHOD("set_doll_interpolation_max_overshot", "speedup"), &NetworkedController::set_doll_interpolation_max_overshot);
-	ClassDB::bind_method(D_METHOD("get_doll_interpolation_max_overshot"), &NetworkedController::get_doll_interpolation_max_overshot);
-
-	ClassDB::bind_method(D_METHOD("set_doll_connection_stats_frame_span", "speedup"), &NetworkedController::set_doll_connection_stats_frame_span);
-	ClassDB::bind_method(D_METHOD("get_doll_connection_stats_frame_span"), &NetworkedController::get_doll_connection_stats_frame_span);
-
 	ClassDB::bind_method(D_METHOD("get_current_input_id"), &NetworkedController::get_current_input_id);
 
 	ClassDB::bind_method(D_METHOD("player_get_pretended_delta"), &NetworkedController::player_get_pretended_delta);
 
-	ClassDB::bind_method(D_METHOD("mark_epoch_as_important"), &NetworkedController::mark_epoch_as_important);
-
-	ClassDB::bind_method(D_METHOD("set_doll_collect_rate_factor", "peer", "factor"), &NetworkedController::set_doll_collect_rate_factor);
-
-	ClassDB::bind_method(D_METHOD("set_doll_peer_active", "peer_id", "active"), &NetworkedController::set_doll_peer_active);
-
 	ClassDB::bind_method(D_METHOD("_rpc_server_send_inputs"), &NetworkedController::_rpc_server_send_inputs);
 	ClassDB::bind_method(D_METHOD("_rpc_set_server_controlled"), &NetworkedController::_rpc_set_server_controlled);
 	ClassDB::bind_method(D_METHOD("_rpc_notify_fps_acceleration"), &NetworkedController::_rpc_notify_fps_acceleration);
-	ClassDB::bind_method(D_METHOD("_rpc_doll_notify_sync_pause"), &NetworkedController::_rpc_doll_notify_sync_pause);
-	ClassDB::bind_method(D_METHOD("_rpc_doll_send_epoch_batch"), &NetworkedController::_rpc_doll_send_epoch_batch);
 
 	ClassDB::bind_method(D_METHOD("is_server_controller"), &NetworkedController::is_server_controller);
 	ClassDB::bind_method(D_METHOD("is_player_controller"), &NetworkedController::is_player_controller);
 	ClassDB::bind_method(D_METHOD("is_doll_controller"), &NetworkedController::is_doll_controller);
 	ClassDB::bind_method(D_METHOD("is_nonet_controller"), &NetworkedController::is_nonet_controller);
-
-	ClassDB::bind_method(D_METHOD("__on_sync_paused"), &NetworkedController::__on_sync_paused);
 
 	GDVIRTUAL_BIND(_collect_inputs, "delta", "buffer");
 	GDVIRTUAL_BIND(_controller_process, "delta", "buffer");
@@ -124,15 +95,7 @@ void NetworkedController::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "min_frames_delay", PROPERTY_HINT_RANGE, "0,100,1"), "set_min_frames_delay", "get_min_frames_delay");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_frames_delay", PROPERTY_HINT_RANGE, "0,100,1"), "set_max_frames_delay", "get_max_frames_delay");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tick_acceleration", PROPERTY_HINT_RANGE, "0.1,20.0,0.01"), "set_tick_acceleration", "get_tick_acceleration");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "doll_sync_rate", PROPERTY_HINT_RANGE, "1,240,1"), "set_doll_sync_rate", "get_doll_sync_rate");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "doll_min_frames_delay", PROPERTY_HINT_RANGE, "0,240,1"), "set_doll_min_frames_delay", "get_doll_min_frames_delay");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "doll_max_frames_delay", PROPERTY_HINT_RANGE, "0,240,1"), "set_doll_max_frames_delay", "get_doll_max_frames_delay");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "doll_net_sensitivity", PROPERTY_HINT_RANGE, "0,1.0,0.00001"), "set_doll_net_sensitivity", "get_doll_net_sensitivity");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "doll_interpolation_max_overshot", PROPERTY_HINT_RANGE, "0.01,5.0,0.01"), "set_doll_interpolation_max_overshot", "get_doll_interpolation_max_overshot");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "doll_connection_stats_frame_span", PROPERTY_HINT_RANGE, "1,1000,1"), "set_doll_connection_stats_frame_span", "get_doll_connection_stats_frame_span");
 
-	ADD_SIGNAL(MethodInfo("doll_sync_started"));
-	ADD_SIGNAL(MethodInfo("doll_sync_paused"));
 	ADD_SIGNAL(MethodInfo("controller_reset"));
 	ADD_SIGNAL(MethodInfo("input_missed", PropertyInfo(Variant::INT, "missing_input_id")));
 	ADD_SIGNAL(MethodInfo("client_speedup_adjusted", PropertyInfo(Variant::INT, "input_worst_receival_time_ms"), PropertyInfo(Variant::INT, "optimal_frame_delay"), PropertyInfo(Variant::INT, "current_frame_delay"), PropertyInfo(Variant::INT, "distance_to_optimal")));
@@ -152,8 +115,6 @@ NetworkedController::NetworkedController() {
 	rpc_config(SNAME("_rpc_server_send_inputs"), rpc_config_unreliable);
 	rpc_config(SNAME("_rpc_set_server_controlled"), rpc_config_reliable);
 	rpc_config(SNAME("_rpc_notify_fps_acceleration"), rpc_config_unreliable);
-	rpc_config(SNAME("_rpc_doll_notify_sync_pause"), rpc_config_reliable); // TODO remove?
-	rpc_config(SNAME("_rpc_doll_send_epoch_batch"), rpc_config_unreliable); // TODO remove?
 }
 
 NetworkedController::~NetworkedController() {
@@ -294,54 +255,6 @@ double NetworkedController::get_tick_acceleration() const {
 	return tick_acceleration;
 }
 
-void NetworkedController::set_doll_sync_rate(uint32_t p_rate) {
-	doll_sync_rate = p_rate;
-}
-
-uint32_t NetworkedController::get_doll_sync_rate() const {
-	return doll_sync_rate;
-}
-
-void NetworkedController::set_doll_min_frames_delay(int p_min) {
-	doll_min_frames_delay = p_min;
-}
-
-int NetworkedController::get_doll_min_frames_delay() const {
-	return doll_min_frames_delay;
-}
-
-void NetworkedController::set_doll_max_frames_delay(int p_max) {
-	doll_max_frames_delay = p_max;
-}
-
-int NetworkedController::get_doll_max_frames_delay() const {
-	return doll_max_frames_delay;
-}
-
-void NetworkedController::set_doll_net_sensitivity(real_t p_sensitivity) {
-	doll_net_sensitivity = p_sensitivity;
-}
-
-real_t NetworkedController::get_doll_net_sensitivity() const {
-	return doll_net_sensitivity;
-}
-
-void NetworkedController::set_doll_interpolation_max_overshot(real_t p_speedup) {
-	doll_interpolation_max_overshot = p_speedup;
-}
-
-real_t NetworkedController::get_doll_interpolation_max_overshot() const {
-	return doll_interpolation_max_overshot;
-}
-
-void NetworkedController::set_doll_connection_stats_frame_span(int p_span) {
-	doll_connection_stats_frame_span = MAX(1, p_span);
-}
-
-int NetworkedController::get_doll_connection_stats_frame_span() const {
-	return doll_connection_stats_frame_span;
-}
-
 uint32_t NetworkedController::get_current_input_id() const {
 	ERR_FAIL_NULL_V(controller, 0);
 	return controller->get_current_input_id();
@@ -350,63 +263,6 @@ uint32_t NetworkedController::get_current_input_id() const {
 real_t NetworkedController::player_get_pretended_delta() const {
 	ERR_FAIL_COND_V_MSG(is_player_controller() == false, 1.0, "This function can be called only on client.");
 	return get_player_controller()->pretended_delta;
-}
-
-void NetworkedController::mark_epoch_as_important() {
-	ERR_FAIL_COND_MSG(is_server_controller() == false, "This function must be called only within the function `collect_epoch_data`.");
-	get_server_controller()->is_epoch_important = true;
-}
-
-void NetworkedController::set_doll_collect_rate_factor(int p_peer, real_t p_factor) {
-	ERR_FAIL_COND_MSG(is_server_controller() == false, "This function can be called only on server.");
-	ServerController *server_controller = static_cast<ServerController *>(controller);
-	const uint32_t pos = server_controller->find_peer(p_peer);
-	if (pos == UINT32_MAX) {
-		// This peers seems disabled, nothing to do here.
-		return;
-	}
-	server_controller->peers[pos].doll_sync_rate_factor = CLAMP(p_factor, 0.001, 1.0);
-}
-
-void NetworkedController::set_doll_peer_active(int p_peer_id, bool p_active) {
-	ERR_FAIL_COND_MSG(is_server_controller() == false, "You can set doll activation only on server");
-	ERR_FAIL_COND_MSG(p_peer_id == get_multiplayer_authority(), "This `peer_id` is equal to the Master `peer_id`, which is not allowed.");
-
-	ServerController *server_controller = static_cast<ServerController *>(controller);
-	const uint32_t pos = server_controller->find_peer(p_peer_id);
-	if (pos == UINT32_MAX) {
-		// This peers seems disabled, nothing to do here.
-		return;
-	}
-	if (server_controller->peers[pos].active == p_active) {
-		// Nothing to do.
-		return;
-	}
-
-	server_controller->peers[pos].active = p_active;
-	// Reset the sync timer.
-	server_controller->peers[pos].doll_sync_timer = 0.0;
-	// Set to 0 so we sync immediately
-	server_controller->peers[pos].doll_sync_time_threshold = 0.0;
-
-	if (p_active == false) {
-		// Notify the doll only for deactivations. The activations are automatically
-		// handled when the first epoch is received.
-		rpc_id(p_peer_id, SNAME("_rpc_doll_notify_sync_pause"), server_controller->epoch);
-	}
-}
-
-void NetworkedController::pause_notify_dolls() {
-	ERR_FAIL_COND_MSG(is_server_controller() == false, "You can pause the dolls only on server. [BUG]");
-
-	// Notify the dolls this actor is disabled.
-	ServerController *server_controller = static_cast<ServerController *>(controller);
-	for (uint32_t i = 0; i < server_controller->peers.size(); i += 1) {
-		if (server_controller->peers[i].active) {
-			// Notify this actor is no more active.
-			rpc_id(server_controller->peers[i].peer, SNAME("_rpc_doll_notify_sync_pause"), server_controller->epoch);
-		}
-	}
 }
 
 void NetworkedController::validate_script_implementation() {
@@ -545,14 +401,12 @@ void NetworkedController::set_inputs_buffer(const BitArray &p_new_buffer, uint32
 
 void NetworkedController::notify_registered_with_synchronizer(SceneSynchronizer *p_synchronizer) {
 	if (scene_synchronizer) {
-		scene_synchronizer->disconnect(SNAME("sync_paused"), Callable(this, SNAME("__on_sync_paused")));
 		scene_synchronizer->unregister_process(this, PROCESSPHASE_PROCESS, callable_mp(this, &NetworkedController::process));
 	}
 
 	scene_synchronizer = p_synchronizer;
 
 	if (scene_synchronizer) {
-		scene_synchronizer->connect(SNAME("sync_paused"), Callable(this, SNAME("__on_sync_paused")));
 		scene_synchronizer->register_process(this, PROCESSPHASE_PROCESS, callable_mp(this, &NetworkedController::process));
 	}
 }
@@ -614,32 +468,12 @@ void NetworkedController::_rpc_notify_fps_acceleration(const Vector<uint8_t> &p_
 #endif
 }
 
-void NetworkedController::_rpc_doll_notify_sync_pause(uint32_t p_epoch) {
-	ERR_FAIL_COND_MSG(is_doll_controller() == false, "Only dolls are supposed to receive this function call");
-
-	static_cast<DollController *>(controller)->pause(p_epoch);
-}
-
-void NetworkedController::_rpc_doll_send_epoch_batch(const Vector<uint8_t> &p_data) {
-	ERR_FAIL_COND_MSG(is_doll_controller() == false, "Only dolls are supposed to receive this function call.");
-	ERR_FAIL_COND_MSG(p_data.size() <= 0, "It's not supposed to receive a 0 size data.");
-
-	static_cast<DollController *>(controller)->receive_epoch(p_data);
-}
-
 void NetworkedController::player_set_has_new_input(bool p_has) {
 	has_player_new_input = p_has;
 }
 
 bool NetworkedController::player_has_new_input() const {
 	return has_player_new_input;
-}
-
-void NetworkedController::__on_sync_paused() {
-	if (controller_type == CONTROLLER_TYPE_DOLL) {
-		DollController *doll = static_cast<DollController *>(controller);
-		doll->pause(doll->current_epoch);
-	}
 }
 
 void NetworkedController::_notification(int p_what) {
@@ -738,7 +572,6 @@ void ServerController::set_enabled(bool p_enable) {
 		return;
 	}
 	enabled = p_enable;
-	node->pause_notify_dolls();
 
 	// ~~ On state change, reset everything to avoid accumulate old data. ~~
 
@@ -750,38 +583,15 @@ void ServerController::set_enabled(bool p_enable) {
 	previous_frame_received_timestamp = UINT32_MAX;
 	network_watcher.reset(0.0);
 	consecutive_input_watcher.reset(0.0);
-
-	// Doll reset.
-	is_epoch_important = false;
 }
 
 void ServerController::clear_peers() {
-	peers.clear();
 }
 
 void ServerController::activate_peer(int p_peer) {
-	// Collects all the dolls.
-
-#ifdef DEBUG_ENABLED
-	// Unreachable because this is the server controller.
-	CRASH_COND(node->get_tree()->get_multiplayer()->is_server() == false);
-#endif
-	if (p_peer == node->get_multiplayer_authority()) {
-		// This is self, so not a doll.
-		return;
-	}
-
-	const uint32_t index = find_peer(p_peer);
-	if (index == UINT32_MAX) {
-		peers.push_back(p_peer);
-	}
 }
 
 void ServerController::deactivate_peer(int p_peer) {
-	const uint32_t index = find_peer(p_peer);
-	if (index != UINT32_MAX) {
-		peers.remove_at_unordered(index);
-	}
 }
 
 void ServerController::receive_inputs(const Vector<uint8_t> &p_data) {
@@ -1097,58 +907,6 @@ void ServerController::notify_send_state() {
 	}
 }
 
-void ServerController::doll_sync(real_t p_delta) {
-	// Advance the epoch.
-	epoch += 1;
-	const real_t sync_rate_time = 1.0 / static_cast<real_t>(node->get_doll_sync_rate());
-
-	bool epoch_state_collected = false;
-
-	// Process each peer and send the data if needed.
-	for (uint32_t i = 0; i < peers.size(); i += 1) {
-		if (peers[i].active == false) {
-			// Nothing to do on this peer.
-			continue;
-		}
-
-		peers[i].doll_sync_timer += p_delta;
-
-		if (is_epoch_important == false && peers[i].doll_sync_timer < peers[i].doll_sync_time_threshold) {
-			// Not time to sync.
-			continue;
-		}
-		peers[i].doll_sync_timer = 0.0;
-		peers[i].doll_sync_time_threshold = sync_rate_time * peers[i].doll_sync_rate_factor;
-
-		// Prepare the epoch_data cache.
-		if (epoch_state_collected == false) {
-			epoch_state_data_cache.begin_write(DOLL_EPOCH_METADATA_SIZE);
-			epoch_state_data_cache.add_real(0.0, DataBuffer::COMPRESSION_LEVEL_1); // Sync time
-			epoch_state_data_cache.add_int(epoch, DataBuffer::COMPRESSION_LEVEL_1);
-
-#ifdef DEBUG_ENABLED
-			// This can't happen because the metadata size is correct.
-			CRASH_COND(epoch_state_data_cache.get_bit_offset() != DOLL_EPOCH_METADATA_SIZE);
-#endif
-
-			//node->native_collect_epoch_data(epoch_state_data_cache);
-			epoch_state_data_cache.dry();
-			epoch_state_collected = true;
-		}
-
-		epoch_state_data_cache.seek(0);
-		epoch_state_data_cache.add_real(peers[i].doll_sync_time_threshold, DataBuffer::COMPRESSION_LEVEL_1);
-
-		// Send the data
-		node->rpc_id(
-				peers[i].peer,
-				SNAME("_rpc_doll_send_epoch_batch"),
-				epoch_state_data_cache.get_buffer().get_bytes());
-	}
-
-	is_epoch_important = false;
-}
-
 int ceil_with_tolerance(double p_value, double p_tolerance) {
 	return Math::ceil(p_value - p_tolerance);
 }
@@ -1219,15 +977,6 @@ void ServerController::adjust_player_tick_rate(double p_delta) {
 				SNAME("_rpc_notify_fps_acceleration"),
 				packet_data);
 	}
-}
-
-uint32_t ServerController::find_peer(int p_peer) const {
-	for (uint32_t i = 0; i < peers.size(); i += 1) {
-		if (peers[i].peer == p_peer) {
-			return i;
-		}
-	}
-	return UINT32_MAX;
 }
 
 AutonomousServerController::AutonomousServerController(
@@ -1608,158 +1357,16 @@ bool PlayerController::can_accept_new_inputs() const {
 }
 
 DollController::DollController(NetworkedController *p_node) :
-		Controller(p_node),
-		network_watcher(node->get_doll_connection_stats_frame_span(), 0) {
+		Controller(p_node) {
 }
 
 void DollController::ready() {}
 
 void DollController::process(double p_delta) {
-	if (future_epoch_buffer.size() <= DOLL_EPOCH_METADATA_SIZE) {
-		// The interpolation epoch is not yet received, nothing to interpolate.
-		return;
-	}
-
-	if (interpolation_time_window <= CMP_EPSILON) {
-		interpolation_alpha = 1.0;
-	} else {
-		interpolation_alpha += p_delta / interpolation_time_window;
-		// Constraint the overshot.
-		interpolation_alpha = MIN(interpolation_alpha, 1.0 + node->get_doll_interpolation_max_overshot());
-	}
-
-	// Allow extrapolation, in case the other para didn't arrive yet.
-	current_epoch = Math::round(Math::lerp(real_t(past_epoch), real_t(future_epoch), interpolation_alpha));
-
-	past_epoch_buffer.begin_read();
-	future_epoch_buffer.begin_read();
-	// Skip metadata.
-	future_epoch_buffer.seek(DOLL_EPOCH_METADATA_SIZE);
-
-	//node->native_apply_epoch(
-	//		p_delta,
-	//		interpolation_alpha,
-	//		past_epoch_buffer,
-	//		future_epoch_buffer);
 }
 
 uint32_t DollController::get_current_input_id() const {
-	return current_epoch;
-}
-
-void DollController::receive_epoch(const Vector<uint8_t> &p_data) {
-	if (unlikely(node->get_scene_synchronizer()->is_enabled() == false)) {
-		// The sync is disabled, nothing to do.
-		return;
-	}
-
-	future_epoch_buffer.copy(p_data);
-	future_epoch_buffer.begin_read();
-	// Read from METADATA:
-	const real_t next_sync_time = future_epoch_buffer.read_real(DataBuffer::COMPRESSION_LEVEL_1);
-	const uint32_t epoch = future_epoch_buffer.read_int(DataBuffer::COMPRESSION_LEVEL_1);
-
-	if (epoch <= paused_epoch) {
-		// The sync is in pause from this epoch, so just discard this received
-		// epoch that may just be a late received epoch.
-		return;
-	}
-
-	if (epoch <= future_epoch) {
-		// This epoch is old, it arrived too late; nothing to do.
-		return;
-	}
-
-	const int64_t current_virtual_delay = int64_t(future_epoch) - int64_t(current_epoch);
-
-	if (current_epoch > future_epoch) {
-		// Make sure we set back the current epoch in case of overshot.
-		// The overshot is wanted to correctly calculate `current_virtual_delay`, but at this point
-		// the overshot need to be normalized.
-		current_epoch = future_epoch;
-	}
-	past_epoch = current_epoch;
-	future_epoch = epoch;
-
-	// Make sure to store the current state, so we can use it to interpolate.
-	// This is necessary so we allow a bit of overshot.
-	past_epoch_buffer.begin_write(0);
-	//node->native_collect_epoch_data(past_epoch_buffer);
-
-	// ~~ Establish the interpolation speed ~~
-
-	// Establish the connection quality by checking if the batch takes
-	// always the same time to arrive.
-	const uint32_t now = OS::get_singleton()->get_ticks_msec();
-
-	// If now is bigger, then the timer has been disabled, so we assume 0.
-
-	real_t packet_arrived_in = 0.0;
-	if (now > epoch_received_timestamp) {
-		packet_arrived_in = static_cast<real_t>(now - epoch_received_timestamp) / 1000.0;
-		const real_t delta_difference = packet_arrived_in - next_epoch_expected_in;
-		network_watcher.push(ABS(delta_difference));
-	}
-	epoch_received_timestamp = now;
-	next_epoch_expected_in = next_sync_time;
-
-	const real_t avg_arrival_delta_time = network_watcher.max();
-	const real_t deviation_arrival_delta_time = network_watcher.get_deviation(avg_arrival_delta_time);
-
-	// The network poorness is computed by looking at all the delta differences between the expected
-	// arrival time and the actual arrival time: the bigger this difference is the more oscillating
-	// the connection is so a virtual delay is needed to make sure the character doesn't bounces.
-	const real_t net_poorness = MIN(1.0, (avg_arrival_delta_time + deviation_arrival_delta_time) / node->get_doll_net_sensitivity());
-
-	const int64_t target_virtual_delay = Math::lerp(
-			node->get_doll_min_frames_delay(),
-			node->get_doll_max_frames_delay(),
-			net_poorness);
-
-	const real_t epochs_span = target_virtual_delay - current_virtual_delay;
-	const real_t frame_time = 1.0 / real_t(Engine::get_singleton()->get_physics_ticks_per_second());
-	interpolation_time_window =
-			next_sync_time +
-			(current_virtual_delay * frame_time) +
-			(epochs_span * frame_time);
-
-	interpolation_alpha = 0.0;
-
-#ifdef DEBUG_ENABLED
-	const bool debug = ProjectSettings::get_singleton()->get_setting("NetworkSynchronizer/debug_doll_speedup");
-	if (debug) {
-		String msg = "~~~~~~~~~~~~~~~\n";
-		msg += "Epoch #" + itos(epoch) + " ";
-		msg += "Epoch arrived in: `" + rtos(packet_arrived_in) + "` \n";
-		msg += "\n";
-		msg += "Avg arrival time difference: `" + rtos(avg_arrival_delta_time) + "` \n";
-		msg += "Deviation arrival difference: `" + rtos(deviation_arrival_delta_time) + "` \n";
-		msg += "Arrival difference: `" + rtos(avg_arrival_delta_time + deviation_arrival_delta_time) + "` \n";
-		msg += "Sensitivity: `" + rtos(node->get_doll_net_sensitivity()) + "` \n";
-		msg += "Network poorness: `" + rtos(net_poorness) + "` \n";
-		msg += "\n";
-		msg += "Next sync time`" + rtos(next_sync_time) + "` \n";
-		msg += "Interpolation time window no speedup `" + rtos(next_sync_time + (current_virtual_delay * frame_time)) + "` \n";
-		msg += "Interpolation time window `" + rtos(interpolation_time_window) + "` \n";
-		msg += "Epochs span `" + rtos(epochs_span) + "` \n";
-		msg += "Current virtual delay `" + itos(current_virtual_delay) + "` \n";
-		msg += "Target virtual delay `" + itos(target_virtual_delay) + "` \n";
-		msg += "Current epoch `" + itos(current_epoch) + "` \n";
-		msg += "Past epoch `" + itos(past_epoch) + "` \n";
-		msg += "Future epoch `" + itos(future_epoch) + "` \n";
-		msg += "~~~~~~~~~~~~~~~\n";
-		print_line(msg);
-	}
-#endif
-}
-
-void DollController::pause(uint32_t p_epoch) {
-	paused_epoch = p_epoch;
-
-	network_watcher.resize(node->get_doll_connection_stats_frame_span(), 0);
-	epoch_received_timestamp = UINT32_MAX;
-
-	node->emit_signal("doll_sync_paused");
+	return UINT32_MAX; // TODO??
 }
 
 NoNetController::NoNetController(NetworkedController *p_node) :

--- a/networked_controller.h
+++ b/networked_controller.h
@@ -161,7 +161,6 @@ private:
 
 	SceneSynchronizer *scene_synchronizer = nullptr;
 
-	bool packet_missing = false;
 	bool has_player_new_input = false;
 
 	// Peer controlling this controller.

--- a/networked_controller.h
+++ b/networked_controller.h
@@ -189,7 +189,11 @@ private:
 
 	ControllerType controller_type = CONTROLLER_TYPE_NULL;
 	Controller *controller = nullptr;
-	DataBuffer inputs_buffer;
+	// Created using `memnew` into the constructor:
+	// The reason why this is a pointer allocated on the heap explicitely using
+	// `memnew` is becouse in Godot 4 GDScript doesn't properly handle non
+	// `memnew` created Objects.
+	DataBuffer *inputs_buffer = nullptr;
 
 	SceneSynchronizer *scene_synchronizer = nullptr;
 
@@ -254,11 +258,11 @@ public:
 	uint32_t get_current_input_id() const;
 
 	const DataBuffer &get_inputs_buffer() const {
-		return inputs_buffer;
+		return *inputs_buffer;
 	}
 
 	DataBuffer &get_inputs_buffer_mut() {
-		return inputs_buffer;
+		return *inputs_buffer;
 	}
 
 	/// Returns the pretended delta used by the player.

--- a/networked_controller.h
+++ b/networked_controller.h
@@ -167,6 +167,8 @@ private:
 	// Peer controlling this controller.
 	int peer_id = -1;
 
+	NetNodeId node_id = NetID_NONE;
+
 public:
 	static void _bind_methods();
 
@@ -259,6 +261,8 @@ public:
 
 	void player_set_has_new_input(bool p_has);
 	bool player_has_new_input() const;
+
+	bool is_realtime_enabled();
 
 protected:
 	void _notification(int p_what);

--- a/networked_controller.h
+++ b/networked_controller.h
@@ -145,7 +145,7 @@ private:
 	/// This margin of error is called `optimal_frame_delay` and it changes
 	/// depending on the connection health:
 	/// it can go from `min_frames_delay` to `max_frames_delay`.
-	int min_frames_delay = 0;
+	int min_frames_delay = 2;
 	int max_frames_delay = 7;
 
 	/// Amount of additional frames produced per second.

--- a/networked_controller.h
+++ b/networked_controller.h
@@ -254,6 +254,12 @@ public:
 protected:
 	void _notification(int p_what);
 	void notify_controller_reset();
+
+public:
+	bool __parse_input_data(
+			const Vector<uint8_t> p_data,
+			void *p_user_pointer,
+			void (*p_input_parse)(void *p_user_pointer, uint32_t p_input_id, int p_input_size_in_bits, const BitArray &p_input));
 };
 
 struct FrameSnapshot {
@@ -280,6 +286,8 @@ struct Controller {
 	virtual void ready() {}
 	virtual uint32_t get_current_input_id() const = 0;
 	virtual void process(double p_delta) = 0;
+
+	virtual void receive_inputs(const Vector<uint8_t> &p_data){};
 
 	virtual void clear_peers() {}
 	virtual void activate_peer(int p_peer) {}
@@ -313,7 +321,7 @@ struct ServerController : public Controller {
 	virtual void activate_peer(int p_peer) override;
 	virtual void deactivate_peer(int p_peer) override;
 
-	virtual void receive_inputs(const Vector<uint8_t> &p_data);
+	virtual void receive_inputs(const Vector<uint8_t> &p_data) override;
 	virtual int get_inputs_count() const;
 
 	/// Fetch the next inputs, returns true if the input is new.
@@ -372,6 +380,8 @@ struct PlayerController : public Controller {
 	bool queue_instant_process(int p_i);
 	virtual void process(double p_delta) override;
 
+	virtual void receive_inputs(const Vector<uint8_t> &p_data) override;
+
 	void store_input_buffer(uint32_t p_id);
 
 	/// Sends an unreliable packet to the server, containing a packed array of
@@ -394,6 +404,7 @@ struct DollController : public Controller {
 	virtual void process(double p_delta) override;
 	// TODO consider make this non virtual
 	virtual uint32_t get_current_input_id() const override;
+	virtual void receive_inputs(const Vector<uint8_t> &p_data) override;
 };
 
 /// This controller is used when the game instance is not a peer of any kind.

--- a/networked_controller.h
+++ b/networked_controller.h
@@ -85,8 +85,6 @@ public:
 	GDVIRTUAL2(_controller_process, real_t, DataBuffer *);
 	GDVIRTUAL2R(bool, _are_inputs_different, DataBuffer *, DataBuffer *);
 	GDVIRTUAL1RC(int, _count_input_size, DataBuffer *);
-	GDVIRTUAL1(_collect_epoch_data, DataBuffer *);
-	GDVIRTUAL4(_apply_epoch, real_t, real_t, DataBuffer *, DataBuffer *);
 
 private:
 	/// When `true`, this controller is controlled by the server: All the clients
@@ -277,8 +275,6 @@ public:
 	virtual void native_controller_process(double p_delta, DataBuffer &p_buffer);
 	virtual bool native_are_inputs_different(DataBuffer &p_buffer_A, DataBuffer &p_buffer_B);
 	virtual uint32_t native_count_input_size(DataBuffer &p_buffer);
-	virtual void native_collect_epoch_data(DataBuffer &r_buffer);
-	virtual void native_apply_epoch(double p_delta, real_t p_interpolation_alpha, DataBuffer &p_past_buffer, DataBuffer &p_future_buffer);
 
 	bool queue_instant_process(int p_i);
 	void process(double p_delta);

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -63,6 +63,7 @@ void initialize_network_synchronizer_module(ModuleInitializationLevel p_level) {
 	GLOBAL_DEF("NetworkSynchronizer/debugger/dump_enabled", false);
 	GLOBAL_DEF("NetworkSynchronizer/debugger/dump_classes", Array());
 	GLOBAL_DEF("NetworkSynchronizer/debugger/log_debug_fps_warnings", true);
+	GLOBAL_DEF("NetworkSynchronizer/debugger/log_debug_rewindings", false);
 }
 
 void uninitialize_network_synchronizer_module(ModuleInitializationLevel p_level) {

--- a/scene_synchronizer.cpp
+++ b/scene_synchronizer.cpp
@@ -65,6 +65,9 @@ void SceneSynchronizer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("reset_synchronizer_mode"), &SceneSynchronizer::reset_synchronizer_mode);
 	ClassDB::bind_method(D_METHOD("clear"), &SceneSynchronizer::clear);
 
+	ClassDB::bind_method(D_METHOD("set_max_deferred_nodes_per_update", "rate"), &SceneSynchronizer::set_max_deferred_nodes_per_update);
+	ClassDB::bind_method(D_METHOD("get_max_deferred_nodes_per_update"), &SceneSynchronizer::get_max_deferred_nodes_per_update);
+
 	ClassDB::bind_method(D_METHOD("set_server_notify_state_interval", "interval"), &SceneSynchronizer::set_server_notify_state_interval);
 	ClassDB::bind_method(D_METHOD("get_server_notify_state_interval"), &SceneSynchronizer::get_server_notify_state_interval);
 
@@ -225,6 +228,14 @@ SceneSynchronizer::SceneSynchronizer() {
 SceneSynchronizer::~SceneSynchronizer() {
 	clear();
 	uninit_synchronizer();
+}
+
+void SceneSynchronizer::set_max_deferred_nodes_per_update(int p_rate) {
+	max_deferred_nodes_per_update = p_rate;
+}
+
+int SceneSynchronizer::get_max_deferred_nodes_per_update() const {
+	return max_deferred_nodes_per_update;
 }
 
 void SceneSynchronizer::set_server_notify_state_interval(real_t p_interval) {
@@ -2198,7 +2209,6 @@ void ServerSynchronizer::process_deferred_sync(real_t p_delta) {
 			continue;
 		}
 
-		const int max_deferred_nodes_per_update = 10; // TODO please make this a variable.
 		int update_node_count = 0;
 
 		group.sort_deferred_node_by_update_priority();
@@ -2209,7 +2219,7 @@ void ServerSynchronizer::process_deferred_sync(real_t p_delta) {
 
 		for (int i = 0; i < int(node_info.size()); ++i) {
 			bool send = true;
-			if (node_info[i].update_priority < 1.0 || update_node_count >= max_deferred_nodes_per_update) {
+			if (node_info[i].update_priority < 1.0 || update_node_count >= scene_synchronizer->max_deferred_nodes_per_update) {
 				send = false;
 			}
 

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -127,6 +127,7 @@ public:
 	static const SyncGroupId GLOBAL_SYNC_GROUP_ID;
 
 private:
+	int max_deferred_nodes_per_update = 30;
 	real_t server_notify_state_interval = 1.0;
 	real_t comparison_float_tolerance = 0.001;
 
@@ -170,8 +171,8 @@ public:
 	SceneSynchronizer();
 	~SceneSynchronizer();
 
-	void set_doll_desync_tolerance(int p_tolerance);
-	int get_doll_desync_tolerance() const;
+	void set_max_deferred_nodes_per_update(int p_rate);
+	int get_max_deferred_nodes_per_update() const;
 
 	void set_server_notify_state_interval(real_t p_interval);
 	real_t get_server_notify_state_interval() const;

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -193,6 +193,7 @@ public:
 	/// - The client doesn't know the ID yet.
 	uint32_t get_node_id(Node *p_node);
 	Node *get_node_from_id(uint32_t p_id);
+	const Node *get_node_from_id_const(uint32_t p_id) const;
 
 	void register_variable(Node *p_node, const StringName &p_variable, const StringName &p_on_change_notify_to = StringName(), NetEventFlag p_flags = NetEventFlag::DEFAULT);
 	void unregister_variable(Node *p_node, const StringName &p_variable);
@@ -303,6 +304,9 @@ public: // ------------------------------------------------------------ INTERNAL
 
 	NetUtility::NodeData *get_node_data_or_null(NetNodeId p_id);
 	const NetUtility::NodeData *get_node_data_or_null(NetNodeId p_id) const;
+
+	NetworkedController *get_controller_for_peer(int p_peer);
+	const NetworkedController *get_controller_for_peer(int p_peer) const;
 
 	/// Returns the latest generated `NetNodeId`.
 	NetNodeId get_biggest_node_id() const;

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -122,6 +122,9 @@ public:
 
 	GDVIRTUAL0(_update_nodes_relevancy);
 
+	/// This SyncGroup contains ALL the registered NodeData.
+	static const RealtimeSyncGroupId REALTIME_GLOBAL_SYNC_GROUP_ID;
+
 private:
 	real_t server_notify_state_interval = 1.0;
 	real_t comparison_float_tolerance = 0.001;
@@ -147,6 +150,10 @@ private:
 
 	// Controller nodes.
 	LocalVector<NetUtility::NodeData *> node_data_controllers;
+
+	/// This array contains a map between the peers and the relevant nodes
+	/// for which the peer is simulating.
+	LocalVector<NetUtility::RealtimeSyncGroup> realtime_sync_groups;
 
 	// Just used to detect when the peer change. TODO Remove this and use a singnal instead.
 	void *peer_ptr = nullptr;
@@ -210,7 +217,12 @@ public:
 
 	void setup_deferred_sync(Node *p_node, const Callable &p_collect_epoch_func, const Callable &p_apply_epoch_func);
 
-	void set_node_sync_realtime(uint32_t p_id, bool p_realtime);
+	RealtimeSyncGroupId create_realtime_sync_group();
+	void add_node_to_realtime_sync_group_by_id(NetNodeId p_node_id, RealtimeSyncGroupId p_group_id);
+	void add_node_to_realtime_sync_group(NetUtility::NodeData *p_node_data, RealtimeSyncGroupId p_group_id);
+	void remove_node_from_realtime_sync_group_by_id(NetNodeId p_node_id, RealtimeSyncGroupId p_group_id);
+	void remove_node_to_realtime_sync_group(NetUtility::NodeData *p_node_data, RealtimeSyncGroupId p_group_id);
+	void move_peer_to_realtime_sync_group(int p_peer_id, RealtimeSyncGroupId p_group_id);
 
 	void start_tracking_scene_changes(Object *p_diff_handle) const;
 	void stop_tracking_scene_changes(Object *p_diff_handle) const;
@@ -294,8 +306,8 @@ public: // ------------------------------------------------------------ INTERNAL
 	void pull_node_changes(NetUtility::NodeData *p_node_data);
 
 	/// Add node data and generates the `NetNodeId` if allowed.
-	void add_node_data(NetUtility::NodeData *p_node_data);
-	void drop_node_data(NetUtility::NodeData *p_node_data);
+	virtual void add_node_data(NetUtility::NodeData *p_node_data);
+	virtual void drop_node_data(NetUtility::NodeData *p_node_data);
 
 	/// Set the node data net id.
 	void set_node_data_id(NetUtility::NodeData *p_node_data, NetNodeId p_id);

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -162,6 +162,9 @@ private:
 	bool cached_process_functions_valid = false;
 	LocalVector<Callable> cached_process_functions[PROCESSPHASE_COUNT];
 
+	// Set at runtime by the constructor by reading the project settings.
+	bool debug_rewindings_enabled = false;
+
 public:
 	static void _bind_methods();
 

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -286,6 +286,9 @@ public: // ------------------------------------------------------------ INTERNAL
 	NetUtility::NodeData *get_node_data(NetNodeId p_id);
 	const NetUtility::NodeData *get_node_data(NetNodeId p_id) const;
 
+	NetUtility::NodeData *get_node_data_or_null(NetNodeId p_id);
+	const NetUtility::NodeData *get_node_data_or_null(NetNodeId p_id) const;
+
 	/// Returns the latest generated `NetNodeId`.
 	NetNodeId get_biggest_node_id() const;
 
@@ -410,10 +413,11 @@ public:
 	void move_peer_to_realtime_sync_group(int p_peer_id, RealtimeSyncGroupId p_group_id);
 
 	void process_snapshot_notificator(real_t p_delta);
+
 	Vector<Variant> generate_snapshot(
 			bool p_force_full_snapshot,
-			const LocalVector<NetUtility::NodeData *> &p_relevant_node_data,
-			const LocalVector<NetUtility::RealtimeSyncGroup::Change> &p_changes) const;
+			const NetUtility::RealtimeSyncGroup &p_group) const;
+
 	void generate_snapshot_node_data(
 			const NetUtility::NodeData *p_node_data,
 			SnapshotGenerationMode p_mode,
@@ -470,7 +474,8 @@ public:
 			void (*p_node_parse)(void *p_user_pointer, NetUtility::NodeData *p_node_data),
 			void (*p_input_id_parse)(void *p_user_pointer, uint32_t p_input_id),
 			void (*p_controller_parse)(void *p_user_pointer, NetUtility::NodeData *p_node_data),
-			void (*p_variable_parse)(void *p_user_pointer, NetUtility::NodeData *p_node_data, NetVarId p_var_id, const Variant &p_value));
+			void (*p_variable_parse)(void *p_user_pointer, NetUtility::NodeData *p_node_data, NetVarId p_var_id, const Variant &p_value),
+			void (*p_node_activation_parse)(void *p_user_pointer, NetUtility::NodeData *p_node_data, bool p_is_active));
 
 	void set_enabled(bool p_enabled);
 

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -227,6 +227,8 @@ public:
 	void sync_group_remove_node_by_id(NetNodeId p_node_id, SyncGroupId p_group_id);
 	void sync_group_remove_node(NetUtility::NodeData *p_node_data, SyncGroupId p_group_id);
 	void sync_group_move_peer_to(int p_peer_id, SyncGroupId p_group_id);
+	SyncGroupId sync_group_get_peer_group(int p_peer_id) const;
+	const LocalVector<int> *sync_group_get_peers(SyncGroupId p_group_id) const;
 	void sync_group_set_deferred_update_rate_by_id(NetNodeId p_node_id, SyncGroupId p_group_id, real_t p_update_rate);
 	void sync_group_set_deferred_update_rate(NetUtility::NodeData *p_node_data, SyncGroupId p_group_id, real_t p_update_rate);
 	real_t sync_group_get_deferred_update_rate_by_id(NetNodeId p_node_id, SyncGroupId p_group_id) const;
@@ -424,6 +426,7 @@ public:
 	void sync_group_add_node(NetUtility::NodeData *p_node_data, SyncGroupId p_group_id, bool p_realtime);
 	void sync_group_remove_node(NetUtility::NodeData *p_node_data, SyncGroupId p_group_id);
 	void sync_group_move_peer_to(int p_peer_id, SyncGroupId p_group_id);
+	const LocalVector<int> *sync_group_get_peers(SyncGroupId p_group_id) const;
 	void sync_group_set_deferred_update_rate(NetUtility::NodeData *p_node_data, SyncGroupId p_group_id, real_t p_update_rate);
 	real_t sync_group_get_deferred_update_rate(const NetUtility::NodeData *p_node_data, SyncGroupId p_group_id) const;
 

--- a/scene_synchronizer.h
+++ b/scene_synchronizer.h
@@ -32,6 +32,7 @@
 
 #include "core/templates/local_vector.h"
 #include "core/templates/oa_hash_map.h"
+#include "data_buffer.h"
 #include "net_utilities.h"
 #include <deque>
 
@@ -471,7 +472,30 @@ class ClientSynchronizer : public Synchronizer {
 
 	RBSet<EndSyncEvent> sync_end_events;
 
-	Vector<uint8_t> latest_received_deferred_sync_data;
+	struct DeferredSyncStream {
+		NetUtility::NodeData *nd = nullptr;
+		DataBuffer past_epoch_buffer;
+		DataBuffer future_epoch_buffer;
+
+		uint32_t past_epoch = NetID_NONE;
+		uint32_t future_epoch = NetID_NONE;
+		real_t alpha_advacing_per_epoch = 1.0;
+		real_t alpha = 0.0;
+
+		DeferredSyncStream() = default;
+		DeferredSyncStream(
+				NetUtility::NodeData *p_nd) :
+				nd(p_nd) {}
+		DeferredSyncStream(
+				NetUtility::NodeData *p_nd,
+				DataBuffer p_past_epoch_buffer,
+				DataBuffer p_future_epoch_buffer) :
+				nd(p_nd),
+				past_epoch_buffer(p_past_epoch_buffer),
+				future_epoch_buffer(p_future_epoch_buffer) {}
+		bool operator==(const DeferredSyncStream &o) const { return nd == o.nd; }
+	};
+	LocalVector<DeferredSyncStream> deferred_sync_stream;
 
 public:
 	ClientSynchronizer(SceneSynchronizer *p_node);

--- a/scene_synchronizer_debugger.cpp
+++ b/scene_synchronizer_debugger.cpp
@@ -563,7 +563,7 @@ void SceneSynchronizerDebugger::databuffer_write(uint32_t p_data_type, uint32_t 
 		return;
 	}
 
-	String val_string = p_variable.stringify();
+	const String val_string = NetUtility::stringify_fast(p_variable);
 
 	frame_dump__data_buffer_writes.push_back(val_string);
 
@@ -583,7 +583,7 @@ void SceneSynchronizerDebugger::databuffer_read(uint32_t p_data_type, uint32_t p
 		return;
 	}
 
-	String val_string = p_variable.stringify();
+	const String val_string = NetUtility::stringify_fast(p_variable);
 
 	frame_dump__data_buffer_reads.push_back(val_string);
 
@@ -699,7 +699,7 @@ void SceneSynchronizerDebugger::dump_tracked_objects(const SceneSynchronizer *p_
 				prefix = "* ";
 			}
 
-			node_dump[prefix + e->get().name + "::" + type_to_string(e->get().type)] = tracked_nodes[i].node->get(e->get().name).stringify();
+			node_dump[prefix + e->get().name + "::" + type_to_string(e->get().type)] = NetUtility::stringify_fast(tracked_nodes[i].node->get(e->get().name));
 		}
 
 		p_dump[node_path] = node_dump;


### PR DESCRIPTION
This PR refactors the `SceneSynchronizer` and the `ControllerSynchronizer`, to:
- Abstract the concept of state interpolation (now any node can be interpolated).
- The State Interpolation now operates using a relevancy parameter, so that more relevant nodes can be updated with higher precision.
- Introduce the `SyncGroup` to optimize and simplify the mechanism used to determine the relevant nodes relative to a client.
- Refactor the `DollController` entirely, now it receive the Player Inputs ASAP and executes it right away: leaving to the rewinder the task to fixup unsyncs.
- Suppress the rewindings logs: With the new doll processing the rewinding will happen by design with high frequency; no need to keep spamming about it.
- Refactored GDScript function call to use object allocated using `memnew`, fixing a segmentation fault.